### PR TITLE
Feat/add search band endpoint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,0 @@
-node_modules
-public
-build
-dist

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx --no-install lint-staged
+npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
             "version": "1.0.0",
             "license": "GPL-3.0",
             "dependencies": {
+                "esmock": "^2.6.5",
                 "fastify": "^4.27.0",
                 "node-html-parser": "^6.1.13"
             },
             "devDependencies": {
                 "@eslint/js": "^9.3.0",
+                "c8": "^9.1.0",
                 "eslint": "^9.3.0",
                 "eslint-config-prettier": "^9.1.0",
                 "globals": "^15.3.0",
@@ -22,6 +24,12 @@
                 "pino-pretty": "^11.1.0",
                 "prettier": "^3.2.5"
             }
+        },
+        "node_modules/@bcoe/v8-coverage": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+            "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+            "dev": true
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
@@ -200,6 +208,40 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@istanbuljs/schema": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "dev": true
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -234,6 +276,12 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/@types/istanbul-lib-coverage": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+            "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+            "dev": true
         },
         "node_modules/abort-controller": {
             "version": "3.0.0",
@@ -458,6 +506,31 @@
                 "ieee754": "^1.2.1"
             }
         },
+        "node_modules/c8": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/c8/-/c8-9.1.0.tgz",
+            "integrity": "sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg==",
+            "dev": true,
+            "dependencies": {
+                "@bcoe/v8-coverage": "^0.2.3",
+                "@istanbuljs/schema": "^0.1.3",
+                "find-up": "^5.0.0",
+                "foreground-child": "^3.1.1",
+                "istanbul-lib-coverage": "^3.2.0",
+                "istanbul-lib-report": "^3.0.1",
+                "istanbul-reports": "^3.1.6",
+                "test-exclude": "^6.0.0",
+                "v8-to-istanbul": "^9.0.0",
+                "yargs": "^17.7.2",
+                "yargs-parser": "^21.1.1"
+            },
+            "bin": {
+                "c8": "bin/c8.js"
+            },
+            "engines": {
+                "node": ">=14.14.0"
+            }
+        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -514,6 +587,66 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/cliui/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -551,6 +684,12 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true
         },
         "node_modules/cookie": {
@@ -710,6 +849,15 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
+        "node_modules/escalade": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+            "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -811,6 +959,14 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/esmock": {
+            "version": "2.6.5",
+            "resolved": "https://registry.npmjs.org/esmock/-/esmock-2.6.5.tgz",
+            "integrity": "sha512-tvFsbtSI9lCuvufbX+UIDn/MoBjTu6UDvQKR8ZmKWHrK3AkioKD2LuTkM75XSngRki3SsBb4uiO58EydQuFCGg==",
+            "engines": {
+                "node": ">=14.16.0"
             }
         },
         "node_modules/espree": {
@@ -1060,17 +1216,6 @@
                 "toad-cache": "^3.3.0"
             }
         },
-        "node_modules/fastify/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/fastq": {
             "version": "1.17.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -1151,12 +1296,43 @@
             "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
             "dev": true
         },
+        "node_modules/foreground-child": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+            "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/forwarded": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
             "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
             }
         },
         "node_modules/get-east-asian-width": {
@@ -1181,6 +1357,27 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/glob-parent": {
@@ -1228,6 +1425,12 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
             "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+            "dev": true
+        },
+        "node_modules/html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
         },
         "node_modules/human-signals": {
@@ -1307,6 +1510,23 @@
                 "node": ">=0.8.19"
             }
         },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+            "dev": true,
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1383,6 +1603,42 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
+        },
+        "node_modules/istanbul-lib-coverage": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-report": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+            "dev": true,
+            "dependencies": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^4.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-reports": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+            "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+            "dev": true,
+            "dependencies": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/joycon": {
             "version": "3.1.1",
@@ -1641,6 +1897,21 @@
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
+        "node_modules/make-dir": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+            "dev": true,
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -1852,6 +2123,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -2060,6 +2340,15 @@
                 "node": ">= 12.13.0"
             }
         },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2207,6 +2496,17 @@
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
             "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
+        },
+        "node_modules/semver": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/set-cookie-parser": {
             "version": "2.6.0",
@@ -2399,6 +2699,20 @@
                 "node": ">=8"
             }
         },
+        "node_modules/test-exclude": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+            "dev": true,
+            "dependencies": {
+                "@istanbuljs/schema": "^0.1.2",
+                "glob": "^7.1.4",
+                "minimatch": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -2451,6 +2765,20 @@
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/v8-to-istanbul": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+            "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.12",
+                "@types/istanbul-lib-coverage": "^2.0.1",
+                "convert-source-map": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.12.0"
             }
         },
         "node_modules/which": {
@@ -2539,6 +2867,15 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
         },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/yaml": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.2.tgz",
@@ -2549,6 +2886,62 @@
             },
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         }
     },
     "lint-staged": {
-        "./src/**/*.{js,json,md}": [
+        "./src/**/*.{js,json,md}, ./tests/**/*.{js,json,md}": [
             "prettier --write",
             "eslint --fix"
         ]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "description": "Metal API is a REST API written in JS for retrieving data from the website Encyclopedia Metallum (https://www.metal-archives.com/)",
     "main": "index.js",
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
+        "test": "node --test-reporter spec --test tests/",
+        "test:coverage": "c8 node --test tests/",
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
         "prepare": "husky"
@@ -20,12 +21,14 @@
     },
     "homepage": "https://github.com/giacomocamerano/metal-api#readme",
     "dependencies": {
+        "esmock": "^2.6.5",
         "fastify": "^4.27.0",
         "node-html-parser": "^6.1.13"
     },
     "type": "module",
     "devDependencies": {
         "@eslint/js": "^9.3.0",
+        "c8": "^9.1.0",
         "eslint": "^9.3.0",
         "eslint-config-prettier": "^9.1.0",
         "globals": "^15.3.0",

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,11 @@
+import Fastify from 'fastify';
+
+const build = (options) => {
+    const fastify = Fastify(options);
+
+    fastify.log.info('Start init');
+    fastify.register(import('./routes/routes.js'));
+    return fastify;
+};
+
+export { build };

--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -1,0 +1,17 @@
+const getJSON = async (url) => {
+    try {
+        const response = await fetch(url);
+        if (!response.ok) {
+            if (response.status === 404) throw new Error('404, Not found');
+            if (response.status === 500) throw new Error('500, internal server error');
+            // For any other server error
+            throw new Error(response.status);
+        }
+        return response.json();
+    } catch (error) {
+        console.error('Fetch', error);
+        throw error;
+    }
+};
+
+export { getJSON };

--- a/src/routes/bands/index.js
+++ b/src/routes/bands/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+async function routes(fastify) {
+    fastify.register(import('./search.js'), {
+        prefix: '/bands',
+    });
+}
+
+export default routes;

--- a/src/routes/bands/index.js
+++ b/src/routes/bands/index.js
@@ -1,9 +1,5 @@
-'use strict';
-
 async function routes(fastify) {
-    fastify.register(import('./search.js'), {
-        prefix: '/bands',
-    });
+    fastify.register(import('./search.js'));
 }
 
 export default routes;

--- a/src/routes/bands/search.js
+++ b/src/routes/bands/search.js
@@ -1,0 +1,57 @@
+import prepareBandResults from './services/prepareBandResults.js';
+import archivesSearchBand from './services/archivesSearch.js';
+
+const searchBand = async (request, reply) => {
+    try {
+        const band = request.params?.band.trim() ?? '';
+        const offset = request.params?.offset ?? 0;
+
+        const data = await archivesSearchBand(band, offset);
+
+        const countTotal = data.iTotalRecords ?? 0;
+        const results = prepareBandResults(data.aaData ?? []);
+        const countCurrent = results?.length ?? 0;
+
+        reply.code(200).send({
+            search: band,
+            offset,
+            countTotal,
+            countCurrent,
+            results,
+        });
+    } catch (error) {
+        reply.code(500).send(error);
+    }
+};
+
+const options = {
+    schema: {
+        params: {
+            type: 'object',
+            properties: {
+                band: { type: 'string', minLength: 1 },
+                offset: { type: 'integer' },
+            },
+            required: ['band'],
+        },
+        response: {
+            200: {
+                type: 'object',
+                properties: {
+                    search: { type: 'string' },
+                    offset: { type: 'integer' },
+                    countTotal: { type: 'integer' },
+                    countCurrent: { type: 'integer' },
+                    results: { type: 'array' },
+                },
+            },
+        },
+    },
+    handler: searchBand,
+};
+
+const search = async (fastify) => {
+    fastify.get('/search/:band', options);
+    fastify.get('/search/:band/:offset', options);
+};
+export default search;

--- a/src/routes/bands/search.js
+++ b/src/routes/bands/search.js
@@ -1,5 +1,5 @@
 import { prepareBandResults } from './services/prepareBandResults.js';
-import archivesSearchBand from './services/archivesSearch.js';
+import { archivesSearchBand } from './services/archivesSearch.js';
 
 const searchBand = async (request, reply) => {
     try {

--- a/src/routes/bands/search.js
+++ b/src/routes/bands/search.js
@@ -1,4 +1,4 @@
-import prepareBandResults from './services/prepareBandResults.js';
+import { prepareBandResults } from './services/prepareBandResults.js';
 import archivesSearchBand from './services/archivesSearch.js';
 
 const searchBand = async (request, reply) => {

--- a/src/routes/bands/services/archivesSearch.js
+++ b/src/routes/bands/services/archivesSearch.js
@@ -1,0 +1,14 @@
+import { getJSON } from '../../../lib/fetch.js';
+
+const archivesSearchBand = async (band = '', offset = 0, forceAll = false) => {
+    if (!band && !forceAll) return { iTotalRecords: 0, aaData: [] };
+    try {
+        return await getJSON(
+            `https://www.metal-archives.com/search/ajax-band-search/?field=name&query=${band.replace(' ', '+')}&sEcho=1&iColumns=3&sColumns=&iDisplayStart=${offset}&iDisplayLength=200&mDataProp_0=0&mDataProp_1=1&mDataProp_2=2`,
+        );
+    } catch (error) {
+        console.error('archivesSearch', error);
+        throw error;
+    }
+};
+export default archivesSearchBand;

--- a/src/routes/bands/services/archivesSearch.js
+++ b/src/routes/bands/services/archivesSearch.js
@@ -1,14 +1,22 @@
 import { getJSON } from '../../../lib/fetch.js';
 
+const prepareBandName = (name) => {
+    return encodeURIComponent(name?.replace(' ', '+') ?? '');
+};
+
+const prepareOffset = (offset = 0) => {
+    return Number(offset) < 0 ? 0 : Number(offset) || 0;
+};
+
 const archivesSearchBand = async (band = '', offset = 0, forceAll = false) => {
-    if (!band && !forceAll) return { iTotalRecords: 0, aaData: [] };
+    if (!band && !forceAll) return { error: '', iTotalRecords: 0, iTotalDisplayRecords: 0, aaData: [] };
     try {
         return await getJSON(
-            `https://www.metal-archives.com/search/ajax-band-search/?field=name&query=${band.replace(' ', '+')}&sEcho=1&iColumns=3&sColumns=&iDisplayStart=${offset}&iDisplayLength=200&mDataProp_0=0&mDataProp_1=1&mDataProp_2=2`,
+            `https://www.metal-archives.com/search/ajax-band-search/?field=name&query=${prepareBandName(band)}&sEcho=1&iColumns=3&sColumns=&iDisplayStart=${prepareOffset(offset)}&iDisplayLength=200&mDataProp_0=0&mDataProp_1=1&mDataProp_2=2`,
         );
     } catch (error) {
         console.error('archivesSearch', error);
         throw error;
     }
 };
-export default archivesSearchBand;
+export { archivesSearchBand, prepareBandName, prepareOffset };

--- a/src/routes/bands/services/prepareBandResults.js
+++ b/src/routes/bands/services/prepareBandResults.js
@@ -1,12 +1,28 @@
 import { parse } from 'node-html-parser';
 
+const getBandIdFromLink = (link) => {
+    return link?.split('/').at(-1) ?? null;
+};
+const getBandNameFromHTML = (html) => {
+    return html?.rawText ?? null;
+};
+const getBandLinkFromHTML = (html) => {
+    try {
+        return html?.getAttribute('href') ?? null;
+    } catch (error) {
+        console.error('getBandIdFromLink', error);
+        return null;
+    }
+};
+
 const prepareBandResults = (data) => {
     return data.reduce((result, bandData) => {
         try {
-            const linkData = parse(bandData);
-            const band = linkData.firstChild.rawText;
-            const link = linkData.firstChild.getAttribute('href');
-            const id = link.split('/').at(-1);
+            if (!bandData || !bandData[0]) throw new Error('Band data invalid');
+            const linkData = parse(bandData[0]);
+            const band = getBandNameFromHTML(linkData.firstChild);
+            const link = getBandLinkFromHTML(linkData.firstChild);
+            const id = getBandIdFromLink(link);
             result.push({
                 band,
                 link,
@@ -17,9 +33,9 @@ const prepareBandResults = (data) => {
             return result;
         } catch (error) {
             console.error('prepareBandResults', error);
-            throw error;
+            return result;
         }
     }, []);
 };
 
-export default prepareBandResults;
+export { getBandIdFromLink, getBandNameFromHTML, getBandLinkFromHTML, prepareBandResults };

--- a/src/routes/bands/services/prepareBandResults.js
+++ b/src/routes/bands/services/prepareBandResults.js
@@ -1,0 +1,25 @@
+import { parse } from 'node-html-parser';
+
+const prepareBandResults = (data) => {
+    return data.reduce((result, bandData) => {
+        try {
+            const linkData = parse(bandData);
+            const band = linkData.firstChild.rawText;
+            const link = linkData.firstChild.getAttribute('href');
+            const id = link.split('/').at(-1);
+            result.push({
+                band,
+                link,
+                id,
+                genre: bandData[1],
+                country: bandData[2],
+            });
+            return result;
+        } catch (error) {
+            console.error('prepareBandResults', error);
+            throw error;
+        }
+    }, []);
+};
+
+export default prepareBandResults;

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -1,0 +1,7 @@
+async function routes(fastify) {
+    fastify.register(import('./bands/index.js'), {
+        prefix: '/bands',
+    });
+}
+
+export default routes;

--- a/src/server.js
+++ b/src/server.js
@@ -1,18 +1,11 @@
-import Fastify from 'fastify';
+import { build } from './app.js';
 import { config } from './config.js';
 
 const environment = process.env.ENVIRONMENT ?? 'development';
-
-const fastify = Fastify({
-    logger: config?.logging[environment] ?? true, // defaults to true if no entry matches in the map
-});
-
-fastify.log.info('Start init');
-fastify.register(import('./routes/bands/index.js'));
-
 const start = async () => {
+    const fastify = build({ logger: config?.logging[environment] ?? true });
     try {
-        await fastify.listen({ port: 3000 });
+        fastify.listen({ port: process.env.PORT || 3000 });
     } catch (err) {
         fastify.log.error(err);
         process.exit(1);

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,7 @@ const fastify = Fastify({
 });
 
 fastify.log.info('Start init');
+fastify.register(import('./routes/bands/index.js'));
 
 const start = async () => {
     try {

--- a/tests/mock_data/ajax-band-search-empty.json
+++ b/tests/mock_data/ajax-band-search-empty.json
@@ -1,0 +1,7 @@
+{
+    "error": "",
+    "iTotalRecords": 0,
+    "iTotalDisplayRecords": 0,
+    "sEcho": 1,
+    "aaData": []
+}

--- a/tests/mock_data/ajax-band-search-immortal.json
+++ b/tests/mock_data/ajax-band-search-immortal.json
@@ -1,0 +1,533 @@
+{
+    "error": "",
+    "iTotalRecords": 105,
+    "iTotalDisplayRecords": 105,
+    "sEcho": 1,
+    "aaData": [
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal/25791\">Immortal</a> (<strong>a.k.a.</strong> [i'mc:tl]) <!-- 8.533402 -->",
+            "Death Metal",
+            "Denmark"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal/44201\">Immortal</a>  <!-- 8.533402 -->",
+            "Death Metal",
+            "Malaysia"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal/3540470418\">Immortal</a>  <!-- 8.533402 -->",
+            "Death Metal",
+            "Mexico"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal/75\">Immortal</a>  <!-- 8.533402 -->",
+            "Black Metal",
+            "Norway"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal/32331\">Immortal</a>  <!-- 8.533402 -->",
+            "Speed/Thrash Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Death_Immortal/3540300218\">Death Immortal</a> (<strong>a.k.a.</strong> Animus of Abbas) <!-- 5.3333764 -->",
+            "Thrash Metal/Metalcore",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Doomed_Immortal/3540441759\">Doomed Immortal</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Abyss/3540426515\">Immortal Abyss</a>  <!-- 5.3333764 -->",
+            "Progressive Black Metal",
+            "Germany"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Aggression/124770\">Immortal Aggression</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Angelica/3540266913\">Immortal Angelica</a>  <!-- 5.3333764 -->",
+            "Gothic/Symphonic Metal",
+            "Finland"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Avenger/29161\">Immortal Avenger</a>  <!-- 5.3333764 -->",
+            "Power Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Ayatollah/3540367062\">Immortal Ayatollah</a>  <!-- 5.3333764 -->",
+            "Black Metal",
+            "France"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Bird/3540373235\">Immortal Bird</a>  <!-- 5.3333764 -->",
+            "Black/Sludge Metal, Crust",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Blade/3540508356\">Immortal Blade</a>  <!-- 5.3333764 -->",
+            "Heavy/Thrash Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Choir/10237\">Immortal Choir</a>  <!-- 5.3333764 -->",
+            "Power/Speed Metal",
+            "Brazil"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Corpse/56230\">Immortal Corpse</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Cringe/12222\">Immortal Cringe</a>  <!-- 5.3333764 -->",
+            "Technical Thrash Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Days/3540361545\">Immortal Days</a>  <!-- 5.3333764 -->",
+            "Progressive Metal",
+            "Sweden"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Death/3540310258\">Immortal Death</a>  <!-- 5.3333764 -->",
+            "Black Metal",
+            "Austria"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Death/3540270664\">Immortal Death</a>  <!-- 5.3333764 -->",
+            "Black Metal",
+            "Chile"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Death/75882\">Immortal Death</a>  <!-- 5.3333764 -->",
+            "Thrash Metal/Punk",
+            "Denmark"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Death/3540511599\">Immortal Death</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "Japan"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Death/34704\">Immortal Death</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "Sweden"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Death/3540501057\">Immortal Death</a>  <!-- 5.3333764 -->",
+            "Black Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Death/3540518604\">Immortal Death</a>  <!-- 5.3333764 -->",
+            "Black/Death Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Destruction/38112\">Immortal Destruction</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Discordia/3540257462\">Immortal Discordia</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "Bulgaria"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Disfigurement/3540533479\">Immortal Disfigurement</a> (<strong>a.k.a.</strong> ID) <!-- 5.3333764 -->",
+            "Symphonic Deathcore",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Divination/3540258138\">Immortal Divination</a>  <!-- 5.3333764 -->",
+            "Death Metal/Grindcore",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Dominion/12576\">Immortal Dominion</a>  <!-- 5.3333764 -->",
+            "Death/Groove/Thrash Metal (early); Groove Metal (later)",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Dying/110112\">Immortal Dying</a>  <!-- 5.3333764 -->",
+            "Melodic Thrash/Death Metal",
+            "Germany"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Empire/3540276196\">Immortal Empire</a>  <!-- 5.3333764 -->",
+            "Black Metal",
+            "United Kingdom"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_End/3540468153\">Immortal End</a>  <!-- 5.3333764 -->",
+            "Thrash/Groove Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Enemy/111388\">Immortal Enemy</a>  <!-- 5.3333764 -->",
+            "Thrash Metal",
+            "Italy"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Execution/3540524959\">Immortal Execution</a>  <!-- 5.3333764 -->",
+            "Melodic Death Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Fate/14807\">Immortal Fate</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Flame/3540516948\">Immortal Flame</a>  <!-- 5.3333764 -->",
+            "Raw Black Metal",
+            "Sweden"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Flesh/5282\">Immortal Flesh</a>  <!-- 5.3333764 -->",
+            "Brutal Death Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Force/3540464485\">Immortal Force</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "Canada"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Forest/3540497549\">Immortal Forest</a>  <!-- 5.3333764 -->",
+            "Raw Black Metal",
+            "Taiwan"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Gate/76266\">Immortal Gate</a>  <!-- 5.3333764 -->",
+            "Black Metal/Ambient",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Grain/65863\">Immortal Grain</a>  <!-- 5.3333764 -->",
+            "Thrash/Death Metal",
+            "Germany"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Guardian/3540316287\">Immortal Guardian</a>  <!-- 5.3333764 -->",
+            "Progressive/Power Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Hammer/9896\">Immortal Hammer</a>  <!-- 5.3333764 -->",
+            "Raw Black Metal",
+            "Slovakia"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Hate/42340\">Immortal Hate</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "Germany"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Legion/99288\">Immortal Legion</a>  <!-- 5.3333764 -->",
+            "Black/Folk Metal",
+            "France"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Metalheads/104825\">Immortal Metalheads</a>  <!-- 5.3333764 -->",
+            "Power Metal",
+            "Germany"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Omen/3540460365\">Immortal Omen</a>  <!-- 5.3333764 -->",
+            "Heavy Metal",
+            "United Kingdom"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Opus/3540543805\">Immortal Opus</a>  <!-- 5.3333764 -->",
+            "Melodic Death Metal",
+            "Brazil"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Orchestra/3540444144\">Immortal Orchestra</a>  <!-- 5.3333764 -->",
+            "Symphonic Doom Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Pain/3540494708\">Immortal Pain</a>  <!-- 5.3333764 -->",
+            "Melodic Death Metal",
+            "Saudi Arabia"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Possession/3636\">Immortal Possession</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "Canada"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Pride/40493\">Immortal Pride</a>  <!-- 5.3333764 -->",
+            "Black Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Prophecy/3540282237\">Immortal Prophecy</a>  <!-- 5.3333764 -->",
+            "Death Metal/Metalcore",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Reaping/3540282368\">Immortal Reaping</a>  <!-- 5.3333764 -->",
+            "Groove/Melodic Death Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Remains/14872\">Immortal Remains</a>  <!-- 5.3333764 -->",
+            "Black Metal",
+            "Germany"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Remains/26844\">Immortal Remains</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Rites/14453\">Immortal Rites</a>  <!-- 5.3333764 -->",
+            "Melodic Death Metal",
+            "Germany"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Rites/114488\">Immortal Rites</a>  <!-- 5.3333764 -->",
+            "Black/Death Metal",
+            "Indonesia"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Rites/82774\">Immortal Rites</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "Poland"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Rites/3540316820\">Immortal Rites</a>  <!-- 5.3333764 -->",
+            "Death/Doom Metal",
+            "United Kingdom"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Rotting/3540464448\">Immortal Rotting</a>  <!-- 5.3333764 -->",
+            "Death/Doom Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Sacrifice/3540532310\">Immortal Sacrifice</a>  <!-- 5.3333764 -->",
+            "Black Metal",
+            "Canada"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Scorn/3540399265\">Immortal Scorn</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "Germany"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Seth/3540354797\">Immortal Seth</a>  <!-- 5.3333764 -->",
+            "Black Metal",
+            "Saudi Arabia"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Shadow/3540422370\">Immortal Shadow</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "Spain"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Sin/3540511667\">Immortal Sin</a>  <!-- 5.3333764 -->",
+            "Heavy Metal",
+            "Brazil"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Sin/3540258635\">Immortal Sin</a>  <!-- 5.3333764 -->",
+            "Melodic Power Metal",
+            "Germany"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Sin/42038\">Immortal Sin</a>  <!-- 5.3333764 -->",
+            "Thrash Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Slave/53297\">Immortal Slave</a>  <!-- 5.3333764 -->",
+            "Gothic Metal",
+            "South Africa"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Soul/106283\">Immortal Soul</a>  <!-- 5.3333764 -->",
+            "Progressive Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Soul/75883\">Immortal Soul</a>  <!-- 5.3333764 -->",
+            "Speed/Thrash Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Souls/1771\">Immortal Souls</a>  <!-- 5.3333764 -->",
+            "Melodic Death Metal",
+            "Finland"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Souls/3540356295\">Immortal Souls</a>  <!-- 5.3333764 -->",
+            "Black/Doom Metal",
+            "Russia"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Souls/3540396988\">Immortal Souls</a>  <!-- 5.3333764 -->",
+            "Thrash Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Suffering/16551\">Immortal Suffering</a>  <!-- 5.3333764 -->",
+            "Brutal Death Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Suicide/3540341882\">Immortal Suicide</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "Russia"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Sun/3540510148\">Immortal Sun</a>  <!-- 5.3333764 -->",
+            "Melodic Black/Death Metal",
+            "Egypt"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_S%C3%BFnn/3540428850\">Immortal Sÿnn</a> (<strong>a.k.a.</strong> Immortal Sin, Immortal Sinn) <!-- 5.3333764 -->",
+            "Heavy Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Tears/10317\">Immortal Tears</a>  <!-- 5.3333764 -->",
+            "Symphonic Black Metal",
+            "Czechia"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Terror/3540317019\">Immortal Terror</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Threat/3540274024\">Immortal Threat</a>  <!-- 5.3333764 -->",
+            "Melodic Death Metal/Metalcore",
+            "Australia"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Throne/72863\">Immortal Throne</a>  <!-- 5.3333764 -->",
+            "Symphonic Black/Death Metal",
+            "Portugal"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Visions/3540406454\">Immortal Visions</a>  <!-- 5.3333764 -->",
+            "Death Metal",
+            "Mexico"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Visions/35793\">Immortal Visions</a>  <!-- 5.3333764 -->",
+            "Death/Doom Metal",
+            "Poland"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_War/3540425648\">Immortal War</a>  <!-- 5.3333764 -->",
+            "Black/Speed Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Wizard/3540438473\">Immortal Wizard</a>  <!-- 5.3333764 -->",
+            "Black Metal",
+            "Chile"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/INRI_Immortal/3540431309\">INRI Immortal</a> (<strong>a.k.a.</strong> I.N.R.I., INRI Immortal) <!-- 5.3333764 -->",
+            "Thrash/Death Metal",
+            "Ecuador"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Once_Immortal/3540521348\">Once Immortal</a>  <!-- 5.3333764 -->",
+            "Groove/Progressive Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Satanic_Immortal/3540441256\">Satanic Immortal</a>  <!-- 5.3333764 -->",
+            "Symphonic Black Metal",
+            "Indonesia"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/The_Immortal/70971\">The Immortal</a>  <!-- 5.3333764 -->",
+            "Heavy/Speed Metal",
+            "Germany"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/I%27mmortal/41531\">I'mmortal</a> (<strong>a.k.a.</strong> Immortal) <!-- 4.266701 -->",
+            "Gothic/Doom Metal",
+            "Russia"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Immortal_Shores_of_Death/3540534724\">Immortal Shores of Death</a>  <!-- 4.266701 -->",
+            "Raw Black Metal",
+            "Unknown"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/My_Immortal_Beloved/118423\">My Immortal Beloved</a>  <!-- 4.266701 -->",
+            "Black Metal",
+            "Brazil"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Servants_of_the_Immortal/3540279374\">Servants of the Immortal</a>  <!-- 4.266701 -->",
+            "Death Metal/Deathcore",
+            "Denmark"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Inmortal/118421\">Inmortal</a> (<strong>a.k.a.</strong> Immortal) <!-- 3.2281163 -->",
+            "Heavy/Gothic Metal",
+            "Argentina"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Enema/3540270723\">Enema</a> (<strong>a.k.a.</strong> Immortal Sense) <!-- 2.0175726 -->",
+            "Melodic Death Metal/Metalcore",
+            "Japan"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Epigraph/3540362552\">Epigraph</a> (<strong>a.k.a.</strong> Immortal Angel) <!-- 2.0175726 -->",
+            "Thrash/Death Metal",
+            "Italy"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Imortal_Pers%C3%A9fone/3540370476\">Imortal Perséfone</a> (<strong>a.k.a.</strong> Immortal Persephone) <!-- 2.0175726 -->",
+            "Black Metal",
+            "Brazil"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Soldado_Inmortal/3540495878\">Soldado Inmortal</a> (<strong>a.k.a.</strong> Soldado Immortal) <!-- 2.0175726 -->",
+            "Death Metal/Deathcore",
+            "Argentina"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Tradicion_Inmortal/3540419760\">Tradicion Inmortal</a> (<strong>a.k.a.</strong> Tradition Immortal) <!-- 2.0175726 -->",
+            "Death Metal",
+            "Argentina"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/D.I.E./3540302370\">D.I.E.</a> (<strong>a.k.a.</strong> Dirty Immortal Evilness) <!-- 1.6140581 -->",
+            "Thrash Metal",
+            "Finland"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Disidente_Inmortal/3540295392\">Disidente Inmortal</a> (<strong>a.k.a.</strong> Dissidente Immortal, Dissident Imortal, Disident Immortal) <!-- 1.4266393 -->",
+            "Heavy Metal",
+            "Argentina"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Imortal_Axe/3540460963\">Imortal Axe</a> (<strong>a.k.a.</strong> Imortal Ax, Immortal Axe) <!-- 1.4123008 -->",
+            "Thrash/Speed Metal",
+            "United States"
+        ],
+        [
+            "<a href=\"https://www.metal-archives.com/bands/Spellsinger/13088\">Spellsinger</a> (<strong>a.k.a.</strong> Immortal Force, SpellSinger) <!-- 1.2105436 -->",
+            "Power Metal",
+            "Germany"
+        ]
+    ]
+}

--- a/tests/mock_data/complete-200-band-data.json
+++ b/tests/mock_data/complete-200-band-data.json
@@ -1,0 +1,2802 @@
+[
+    {
+        "link": "https://www.metal-archives.com/bands/%21T.O.O.H.%21/16265",
+        "id": "16265",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%21T.O.O.H.%21/16265\">!T.O.O.H.!</a>  <!-- 1 -->",
+        "genre": "Progressive Death Metal/Grindcore",
+        "country": "Czechia",
+        "band": "!T.O.O.H.!",
+        "preparedBandName": "!T.O.O.H.!",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%21T.O.O.H.%21/16265\">!T.O.O.H.!</a>  <!-- 1 -->",
+            "Progressive Death Metal/Grindcore",
+            "Czechia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%21%C3%BAl../109481",
+        "id": "109481",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%21%C3%BAl../109481\">!úl..</a>  <!-- 1 -->",
+        "genre": "Death/Black Metal",
+        "country": "Czechia",
+        "band": "!úl..",
+        "preparedBandName": "!%C3%BAl..",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%21%C3%BAl../109481\">!úl..</a>  <!-- 1 -->",
+            "Death/Black Metal",
+            "Czechia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%24Greed%24/3540423227",
+        "id": "3540423227",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%24Greed%24/3540423227\">$Greed$</a>  <!-- 1 -->",
+        "genre": "Heavy/Thrash Metal",
+        "country": "United States",
+        "band": "$Greed$",
+        "preparedBandName": "%24Greed%24",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%24Greed%24/3540423227\">$Greed$</a>  <!-- 1 -->",
+            "Heavy/Thrash Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%24ilverdollar/60323",
+        "id": "60323",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%24ilverdollar/60323\">$ilverdollar</a>  <!-- 1 -->",
+        "genre": "Heavy/Power Metal",
+        "country": "Sweden",
+        "band": "$ilverdollar",
+        "preparedBandName": "%24ilverdollar",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%24ilverdollar/60323\">$ilverdollar</a>  <!-- 1 -->",
+            "Heavy/Power Metal",
+            "Sweden"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%24lamboy%24/3540445218",
+        "id": "3540445218",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%24lamboy%24/3540445218\">$lamboy$</a>  <!-- 1 -->",
+        "genre": "Death Metal/Grindcore (early); Slam/Brutal Death Metal (later)",
+        "country": "United States",
+        "band": "$lamboy$",
+        "preparedBandName": "%24lamboy%24",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%24lamboy%24/3540445218\">$lamboy$</a>  <!-- 1 -->",
+            "Death Metal/Grindcore (early); Slam/Brutal Death Metal (later)",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%24lutrot/3540438154",
+        "id": "3540438154",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%24lutrot/3540438154\">$lutrot</a>  <!-- 1 -->",
+        "genre": "Slam/Brutal Death Metal",
+        "country": "United States",
+        "band": "$lutrot",
+        "preparedBandName": "%24lutrot",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%24lutrot/3540438154\">$lutrot</a>  <!-- 1 -->",
+            "Slam/Brutal Death Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%24uicide_%24olution/35843",
+        "id": "35843",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%24uicide_%24olution/35843\">$uicide $olution</a>  <!-- 1 -->",
+        "genre": "Heavy Metal (early); Melodic Death/Groove Metal (later)",
+        "country": "Singapore",
+        "band": "$uicide $olution",
+        "preparedBandName": "%24uicide%2B%24olution",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%24uicide_%24olution/35843\">$uicide $olution</a>  <!-- 1 -->",
+            "Heavy Metal (early); Melodic Death/Groove Metal (later)",
+            "Singapore"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%27Ain/3540451613",
+        "id": "3540451613",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%27Ain/3540451613\">'Ain</a>  <!-- 1 -->",
+        "genre": "Symphonic Metal",
+        "country": "Mexico",
+        "band": "'Ain",
+        "preparedBandName": "'Ain",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%27Ain/3540451613\">'Ain</a>  <!-- 1 -->",
+            "Symphonic Metal",
+            "Mexico"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%27Big_Jim%27_Shively/3540352410",
+        "id": "3540352410",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%27Big_Jim%27_Shively/3540352410\">'Big Jim' Shively</a>  <!-- 1 -->",
+        "genre": "Doom Metal/Psychedelic Rock",
+        "country": "United States",
+        "band": "'Big Jim' Shively",
+        "preparedBandName": "'Big%2BJim'%20Shively",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%27Big_Jim%27_Shively/3540352410\">'Big Jim' Shively</a>  <!-- 1 -->",
+            "Doom Metal/Psychedelic Rock",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%27Iisn%C3%A1%C3%A1h%C3%AD/3540457717",
+        "id": "3540457717",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%27Iisn%C3%A1%C3%A1h%C3%AD/3540457717\">'Iisnááhí</a>  <!-- 1 -->",
+        "genre": "Black Metal",
+        "country": "United States",
+        "band": "'Iisnááhí",
+        "preparedBandName": "'Iisn%C3%A1%C3%A1h%C3%AD",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%27Iisn%C3%A1%C3%A1h%C3%AD/3540457717\">'Iisnááhí</a>  <!-- 1 -->",
+            "Black Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%27Neath/70489",
+        "id": "70489",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%27Neath/70489\">'Neath</a>  <!-- 1 -->",
+        "genre": "Progressive Death Metal",
+        "country": "Australia",
+        "band": "'Neath",
+        "preparedBandName": "'Neath",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%27Neath/70489\">'Neath</a>  <!-- 1 -->",
+            "Progressive Death Metal",
+            "Australia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28%27M%27%29_Inc./3540373050",
+        "id": "3540373050",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28%27M%27%29_Inc./3540373050\">('M') Inc.</a>  <!-- 1 -->",
+        "genre": "Death Metal",
+        "country": "United States",
+        "band": "('M') Inc.",
+        "preparedBandName": "('M')%2BInc.",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28%27M%27%29_Inc./3540373050\">('M') Inc.</a>  <!-- 1 -->",
+            "Death Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28%28%28...%29%29%29/3540352418",
+        "id": "3540352418",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28%28%28...%29%29%29/3540352418\">(((...)))</a>  <!-- 1 -->",
+        "genre": "Drone/Doom Metal/Noise",
+        "country": "Indonesia",
+        "band": "(((...)))",
+        "preparedBandName": "(((...)))",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28%28%28...%29%29%29/3540352418\">(((...)))</a>  <!-- 1 -->",
+            "Drone/Doom Metal/Noise",
+            "Indonesia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28%28%28o%29%29%29/3540477290",
+        "id": "3540477290",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28%28%28o%29%29%29/3540477290\">(((o)))</a>  <!-- 1 -->",
+        "genre": "Black Metal",
+        "country": "Mexico",
+        "band": "(((o)))",
+        "preparedBandName": "(((o)))",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28%28%28o%29%29%29/3540477290\">(((o)))</a>  <!-- 1 -->",
+            "Black Metal",
+            "Mexico"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28%28Auman%29%29/3540349047",
+        "id": "3540349047",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28%28Auman%29%29/3540349047\">((Auman))</a>  <!-- 1 -->",
+        "genre": "Heavy/Stoner Metal/Hard Rock",
+        "country": "Indonesia",
+        "band": "((Auman))",
+        "preparedBandName": "((Auman))",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28%28Auman%29%29/3540349047\">((Auman))</a>  <!-- 1 -->",
+            "Heavy/Stoner Metal/Hard Rock",
+            "Indonesia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28%28Blindsight%29%29/3540528376",
+        "id": "3540528376",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28%28Blindsight%29%29/3540528376\">((Blindsight))</a>  <!-- 1 -->",
+        "genre": "Groove Metal/Hardcore",
+        "country": "United Kingdom",
+        "band": "((Blindsight))",
+        "preparedBandName": "((Blindsight))",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28%28Blindsight%29%29/3540528376\">((Blindsight))</a>  <!-- 1 -->",
+            "Groove Metal/Hardcore",
+            "United Kingdom"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28%28Thorlock%29%29/3540288214",
+        "id": "3540288214",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28%28Thorlock%29%29/3540288214\">((Thorlock))</a>  <!-- 1 -->",
+        "genre": "Sludge/Stoner Metal",
+        "country": "United States",
+        "band": "((Thorlock))",
+        "preparedBandName": "((Thorlock))",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28%28Thorlock%29%29/3540288214\">((Thorlock))</a>  <!-- 1 -->",
+            "Sludge/Stoner Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%280%29/3540429542",
+        "id": "3540429542",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%280%29/3540429542\">(0)</a>  <!-- 1 -->",
+        "genre": "Progressive Metal",
+        "country": "Denmark",
+        "band": "(0)",
+        "preparedBandName": "(0)",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%280%29/3540429542\">(0)</a>  <!-- 1 -->",
+            "Progressive Metal",
+            "Denmark"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%282794%29/3540530488",
+        "id": "3540530488",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%282794%29/3540530488\">(2794)</a>  <!-- 1 -->",
+        "genre": "Atmospheric Sludge/Post-Metal",
+        "country": "Germany",
+        "band": "(2794)",
+        "preparedBandName": "(2794)",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%282794%29/3540530488\">(2794)</a>  <!-- 1 -->",
+            "Atmospheric Sludge/Post-Metal",
+            "Germany"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28Cyber%5D.ocalypse%29_.._._../3540453682",
+        "id": "3540453682",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28Cyber%5D.ocalypse%29_.._._../3540453682\">(Cyber].ocalypse) .. . ..</a>  <!-- 1 -->",
+        "genre": "Doom Metal/Rock",
+        "country": "Russia",
+        "band": "(Cyber].ocalypse) .. . ..",
+        "preparedBandName": "(Cyber%5D.ocalypse)%2B..%20.%20..",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28Cyber%5D.ocalypse%29_.._._../3540453682\">(Cyber].ocalypse) .. . ..</a>  <!-- 1 -->",
+            "Doom Metal/Rock",
+            "Russia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28Deadly%29_Silence/3540266881",
+        "id": "3540266881",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28Deadly%29_Silence/3540266881\">(Deadly) Silence</a>  <!-- 1 -->",
+        "genre": "Thrash/Groove Metal",
+        "country": "Germany",
+        "band": "(Deadly) Silence",
+        "preparedBandName": "(Deadly)%2BSilence",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28Deadly%29_Silence/3540266881\">(Deadly) Silence</a>  <!-- 1 -->",
+            "Thrash/Groove Metal",
+            "Germany"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28Dolch%29/3540460927",
+        "id": "3540460927",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28Dolch%29/3540460927\">(Dolch)</a>  <!-- 1 -->",
+        "genre": "Drone/Doom/Black Metal/Ambient (early); Gothic Rock/Darkwave (later)",
+        "country": "Germany",
+        "band": "(Dolch)",
+        "preparedBandName": "(Dolch)",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28Dolch%29/3540460927\">(Dolch)</a>  <!-- 1 -->",
+            "Drone/Doom/Black Metal/Ambient (early); Gothic Rock/Darkwave (later)",
+            "Germany"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28drama%29/108171",
+        "id": "108171",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28drama%29/108171\">(drama)</a>  <!-- 1 -->",
+        "genre": "Sludge/Doom Metal",
+        "country": "Croatia",
+        "band": "(drama)",
+        "preparedBandName": "(drama)",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28drama%29/108171\">(drama)</a>  <!-- 1 -->",
+            "Sludge/Doom Metal",
+            "Croatia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28Echo%29/3540268831",
+        "id": "3540268831",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28Echo%29/3540268831\">(Echo)</a>  <!-- 1 -->",
+        "genre": "Melodic Death/Doom Metal",
+        "country": "Italy",
+        "band": "(Echo)",
+        "preparedBandName": "(Echo)",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28Echo%29/3540268831\">(Echo)</a>  <!-- 1 -->",
+            "Melodic Death/Doom Metal",
+            "Italy"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28god-rot%29/100527",
+        "id": "100527",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28god-rot%29/100527\">(god-rot)</a>  <!-- 1 -->",
+        "genre": "Progressive Death Metal/Grindcore",
+        "country": "United States",
+        "band": "(god-rot)",
+        "preparedBandName": "(god-rot)",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28god-rot%29/100527\">(god-rot)</a>  <!-- 1 -->",
+            "Progressive Death Metal/Grindcore",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28Jhator%29/3540350094",
+        "id": "3540350094",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28Jhator%29/3540350094\">(Jhator)</a>  <!-- 1 -->",
+        "genre": "Death 'n' Roll",
+        "country": "Sweden",
+        "band": "(Jhator)",
+        "preparedBandName": "(Jhator)",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28Jhator%29/3540350094\">(Jhator)</a>  <!-- 1 -->",
+            "Death 'n' Roll",
+            "Sweden"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28Lone%29_Wolf_%26_Cub/3540455560",
+        "id": "3540455560",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28Lone%29_Wolf_%26_Cub/3540455560\">(Lone) Wolf & Cub</a>  <!-- 1 -->",
+        "genre": "Progressive Metalcore",
+        "country": "United States",
+        "band": "(Lone) Wolf & Cub",
+        "preparedBandName": "(Lone)%2BWolf%20%26%20Cub",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28Lone%29_Wolf_%26_Cub/3540455560\">(Lone) Wolf & Cub</a>  <!-- 1 -->",
+            "Progressive Metalcore",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28Origin_Unknown%29/3540463237",
+        "id": "3540463237",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28Origin_Unknown%29/3540463237\">(Origin Unknown)</a>  <!-- 1 -->",
+        "genre": "Metalcore/Crossover",
+        "country": "United States",
+        "band": "(Origin Unknown)",
+        "preparedBandName": "(Origin%2BUnknown)",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28Origin_Unknown%29/3540463237\">(Origin Unknown)</a>  <!-- 1 -->",
+            "Metalcore/Crossover",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28Psychoparalysis%29/3540306619",
+        "id": "3540306619",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28Psychoparalysis%29/3540306619\">(Psychoparalysis)</a>  <!-- 1 -->",
+        "genre": "Progressive Death Metal",
+        "country": "Finland",
+        "band": "(Psychoparalysis)",
+        "preparedBandName": "(Psychoparalysis)",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28Psychoparalysis%29/3540306619\">(Psychoparalysis)</a>  <!-- 1 -->",
+            "Progressive Death Metal",
+            "Finland"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28Rabbit%29/3540418351",
+        "id": "3540418351",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28Rabbit%29/3540418351\">(Rabbit)</a>  <!-- 1 -->",
+        "genre": "Drone/Doom Metal",
+        "country": "United States",
+        "band": "(Rabbit)",
+        "preparedBandName": "(Rabbit)",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28Rabbit%29/3540418351\">(Rabbit)</a>  <!-- 1 -->",
+            "Drone/Doom Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28sic%29/3540292626",
+        "id": "3540292626",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28sic%29/3540292626\">(sic)</a>  <!-- 1 -->",
+        "genre": "Death Metal",
+        "country": "United States",
+        "band": "(sic)",
+        "preparedBandName": "(sic)",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28sic%29/3540292626\">(sic)</a>  <!-- 1 -->",
+            "Death Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28Sworn%29/3540323338",
+        "id": "3540323338",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28Sworn%29/3540323338\">(Sworn)</a>  <!-- 1 -->",
+        "genre": "Progressive Metal",
+        "country": "France",
+        "band": "(Sworn)",
+        "preparedBandName": "(Sworn)",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28Sworn%29/3540323338\">(Sworn)</a>  <!-- 1 -->",
+            "Progressive Metal",
+            "France"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28V.E.G.A.%29/20535",
+        "id": "20535",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28V.E.G.A.%29/20535\">(V.E.G.A.)</a>  <!-- 1 -->",
+        "genre": "Experimental Black Metal, Experimental/Electronic/Ambient",
+        "country": "International",
+        "band": "(V.E.G.A.)",
+        "preparedBandName": "(V.E.G.A.)",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28V.E.G.A.%29/20535\">(V.E.G.A.)</a>  <!-- 1 -->",
+            "Experimental Black Metal, Experimental/Electronic/Ambient",
+            "International"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%28waning%29/3540349778",
+        "id": "3540349778",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%28waning%29/3540349778\">(waning)</a>  <!-- 1 -->",
+        "genre": "Dark Ambient (early); Doom/Post-Metal (later)",
+        "country": "United States",
+        "band": "(waning)",
+        "preparedBandName": "(waning)",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%28waning%29/3540349778\">(waning)</a>  <!-- 1 -->",
+            "Dark Ambient (early); Doom/Post-Metal (later)",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%29October%28/3540410502",
+        "id": "3540410502",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%29October%28/3540410502\">)October(</a>  <!-- 1 -->",
+        "genre": "Black Metal",
+        "country": "Spain",
+        "band": ")October(",
+        "preparedBandName": ")October(",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%29October%28/3540410502\">)October(</a>  <!-- 1 -->",
+            "Black Metal",
+            "Spain"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/%2B3_Broadsword/3540257015",
+        "id": "3540257015",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/%2B3_Broadsword/3540257015\">+3 Broadsword</a>  <!-- 1 -->",
+        "genre": "Black Metal",
+        "country": "Australia",
+        "band": "+3 Broadsword",
+        "preparedBandName": "%2B3%2BBroadsword",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/%2B3_Broadsword/3540257015\">+3 Broadsword</a>  <!-- 1 -->",
+            "Black Metal",
+            "Australia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/-_-_-/3540353044",
+        "id": "3540353044",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/-_-_-/3540353044\">- - -</a>  <!-- 1 -->",
+        "genre": "Atmospheric Black Metal",
+        "country": "Sweden",
+        "band": "- - -",
+        "preparedBandName": "-%2B-%20-",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/-_-_-/3540353044\">- - -</a>  <!-- 1 -->",
+            "Atmospheric Black Metal",
+            "Sweden"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/-I-/3540525033",
+        "id": "3540525033",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/-I-/3540525033\">-I-</a>  <!-- 1 -->",
+        "genre": "Black Metal",
+        "country": "Canada",
+        "band": "-I-",
+        "preparedBandName": "-I-",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/-I-/3540525033\">-I-</a>  <!-- 1 -->",
+            "Black Metal",
+            "Canada"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/.../3540257897",
+        "id": "3540257897",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/.../3540257897\">...</a>  <!-- 1 -->",
+        "genre": "Depressive Black Metal (early); Post-Black Metal (later)",
+        "country": "International",
+        "band": "...",
+        "preparedBandName": "...",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/.../3540257897\">...</a>  <!-- 1 -->",
+            "Depressive Black Metal (early); Post-Black Metal (later)",
+            "International"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...Aaaarrghh.../33438",
+        "id": "33438",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...Aaaarrghh.../33438\">...Aaaarrghh...</a>  <!-- 1 -->",
+        "genre": "Black Metal",
+        "country": "Türkiye",
+        "band": "...Aaaarrghh...",
+        "preparedBandName": "...Aaaarrghh...",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...Aaaarrghh.../33438\">...Aaaarrghh...</a>  <!-- 1 -->",
+            "Black Metal",
+            "Türkiye"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...and_Darkness_Follows/3540439329",
+        "id": "3540439329",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...and_Darkness_Follows/3540439329\">...and Darkness Follows</a>  <!-- 1 -->",
+        "genre": "Atmospheric Black Metal",
+        "country": "United Kingdom",
+        "band": "...and Darkness Follows",
+        "preparedBandName": "...and%2BDarkness%20Follows",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...and_Darkness_Follows/3540439329\">...and Darkness Follows</a>  <!-- 1 -->",
+            "Atmospheric Black Metal",
+            "United Kingdom"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...and_Here_I_Lie/19272",
+        "id": "19272",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...and_Here_I_Lie/19272\">...and Here I Lie</a>  <!-- 1 -->",
+        "genre": "Death/Doom Metal",
+        "country": "United States",
+        "band": "...and Here I Lie",
+        "preparedBandName": "...and%2BHere%20I%20Lie",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...and_Here_I_Lie/19272\">...and Here I Lie</a>  <!-- 1 -->",
+            "Death/Doom Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...and_Oceans/231",
+        "id": "231",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...and_Oceans/231\">...and Oceans</a>  <!-- 1 -->",
+        "genre": "Symphonic Black Metal (early/later); Industrial/Electronic Metal (mid)",
+        "country": "Finland",
+        "band": "...and Oceans",
+        "preparedBandName": "...and%2BOceans",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...and_Oceans/231\">...and Oceans</a>  <!-- 1 -->",
+            "Symphonic Black Metal (early/later); Industrial/Electronic Metal (mid)",
+            "Finland"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...and_Silence_Remains/3540461037",
+        "id": "3540461037",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...and_Silence_Remains/3540461037\">...and Silence Remains</a>  <!-- 1 -->",
+        "genre": "Power/Speed Metal",
+        "country": "Australia",
+        "band": "...and Silence Remains",
+        "preparedBandName": "...and%2BSilence%20Remains",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...and_Silence_Remains/3540461037\">...and Silence Remains</a>  <!-- 1 -->",
+            "Power/Speed Metal",
+            "Australia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...and_They_Will_Meet_God/24544",
+        "id": "24544",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...and_They_Will_Meet_God/24544\">...and They Will Meet God</a>  <!-- 1 -->",
+        "genre": "Melodic Death Metal/Crossover",
+        "country": "United States",
+        "band": "...and They Will Meet God",
+        "preparedBandName": "...and%2BThey%20Will%20Meet%20God",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...and_They_Will_Meet_God/24544\">...and They Will Meet God</a>  <!-- 1 -->",
+            "Melodic Death Metal/Crossover",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...as_Bitterness_Reigns/3540486446",
+        "id": "3540486446",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...as_Bitterness_Reigns/3540486446\">...as Bitterness Reigns</a>  <!-- 1 -->",
+        "genre": "Death Metal",
+        "country": "Germany",
+        "band": "...as Bitterness Reigns",
+        "preparedBandName": "...as%2BBitterness%20Reigns",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...as_Bitterness_Reigns/3540486446\">...as Bitterness Reigns</a>  <!-- 1 -->",
+            "Death Metal",
+            "Germany"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...But_a_Thought/3540378506",
+        "id": "3540378506",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...But_a_Thought/3540378506\">...But a Thought</a>  <!-- 1 -->",
+        "genre": "Progressive Metal",
+        "country": "International",
+        "band": "...But a Thought",
+        "preparedBandName": "...But%2Ba%20Thought",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...But_a_Thought/3540378506\">...But a Thought</a>  <!-- 1 -->",
+            "Progressive Metal",
+            "International"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...Dieses/3540355934",
+        "id": "3540355934",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...Dieses/3540355934\">...Dieses</a>  <!-- 1 -->",
+        "genre": "Black Metal",
+        "country": "Russia",
+        "band": "...Dieses",
+        "preparedBandName": "...Dieses",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...Dieses/3540355934\">...Dieses</a>  <!-- 1 -->",
+            "Black Metal",
+            "Russia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...Do_Fundo..._Abismo/3540326997",
+        "id": "3540326997",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...Do_Fundo..._Abismo/3540326997\">...Do Fundo... Abismo</a>  <!-- 1 -->",
+        "genre": "Death/Doom Metal",
+        "country": "Brazil",
+        "band": "...Do Fundo... Abismo",
+        "preparedBandName": "...Do%2BFundo...%20Abismo",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...Do_Fundo..._Abismo/3540326997\">...Do Fundo... Abismo</a>  <!-- 1 -->",
+            "Death/Doom Metal",
+            "Brazil"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...Fallen/3540447342",
+        "id": "3540447342",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...Fallen/3540447342\">...Fallen</a>  <!-- 1 -->",
+        "genre": "Gothic/Doom Metal/Ambient",
+        "country": "Finland",
+        "band": "...Fallen",
+        "preparedBandName": "...Fallen",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...Fallen/3540447342\">...Fallen</a>  <!-- 1 -->",
+            "Gothic/Doom Metal/Ambient",
+            "Finland"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...from_the_Abyss/3540443406",
+        "id": "3540443406",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...from_the_Abyss/3540443406\">...from the Abyss</a>  <!-- 1 -->",
+        "genre": "Death Metal",
+        "country": "Brazil",
+        "band": "...from the Abyss",
+        "preparedBandName": "...from%2Bthe%20Abyss",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...from_the_Abyss/3540443406\">...from the Abyss</a>  <!-- 1 -->",
+            "Death Metal",
+            "Brazil"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...from_the_Deep/3540399273",
+        "id": "3540399273",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...from_the_Deep/3540399273\">...from the Deep</a>  <!-- 1 -->",
+        "genre": "Technical/Melodic Death Metal",
+        "country": "Canada",
+        "band": "...from the Deep",
+        "preparedBandName": "...from%2Bthe%20Deep",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...from_the_Deep/3540399273\">...from the Deep</a>  <!-- 1 -->",
+            "Technical/Melodic Death Metal",
+            "Canada"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...in_Agony_of_the_Eclipsed_Moon/3540466149",
+        "id": "3540466149",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...in_Agony_of_the_Eclipsed_Moon/3540466149\">...in Agony of the Eclipsed Moon</a>  <!-- 1 -->",
+        "genre": "Black Metal/Dark Ambient",
+        "country": "United States",
+        "band": "...in Agony of the Eclipsed Moon",
+        "preparedBandName": "...in%2BAgony%20of%20the%20Eclipsed%20Moon",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...in_Agony_of_the_Eclipsed_Moon/3540466149\">...in Agony of the Eclipsed Moon</a>  <!-- 1 -->",
+            "Black Metal/Dark Ambient",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...in_Deviltry/3540471679",
+        "id": "3540471679",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...in_Deviltry/3540471679\">...in Deviltry</a>  <!-- 1 -->",
+        "genre": "Melodic Doom Metal",
+        "country": "International",
+        "band": "...in Deviltry",
+        "preparedBandName": "...in%2BDeviltry",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...in_Deviltry/3540471679\">...in Deviltry</a>  <!-- 1 -->",
+            "Melodic Doom Metal",
+            "International"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...in_Her_Lie/53017",
+        "id": "53017",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...in_Her_Lie/53017\">...in Her Lie</a>  <!-- 1 -->",
+        "genre": "Gothic/Doom Metal",
+        "country": "France",
+        "band": "...in Her Lie",
+        "preparedBandName": "...in%2BHer%20Lie",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...in_Her_Lie/53017\">...in Her Lie</a>  <!-- 1 -->",
+            "Gothic/Doom Metal",
+            "France"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...of_Celestial/3540289576",
+        "id": "3540289576",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...of_Celestial/3540289576\">...of Celestial</a>  <!-- 1 -->",
+        "genre": "Symphonic Black/Death Metal (early); Melodic Death Metal (later)",
+        "country": "Ukraine",
+        "band": "...of Celestial",
+        "preparedBandName": "...of%2BCelestial",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...of_Celestial/3540289576\">...of Celestial</a>  <!-- 1 -->",
+            "Symphonic Black/Death Metal (early); Melodic Death Metal (later)",
+            "Ukraine"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...of_Dream_and_Drama/27211",
+        "id": "27211",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...of_Dream_and_Drama/27211\">...of Dream and Drama</a>  <!-- 1 -->",
+        "genre": "Doom/Death Metal",
+        "country": "Spain",
+        "band": "...of Dream and Drama",
+        "preparedBandName": "...of%2BDream%20and%20Drama",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...of_Dream_and_Drama/27211\">...of Dream and Drama</a>  <!-- 1 -->",
+            "Doom/Death Metal",
+            "Spain"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...of_Drowning_Heaven/3540375137",
+        "id": "3540375137",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...of_Drowning_Heaven/3540375137\">...of Drowning Heaven</a>  <!-- 1 -->",
+        "genre": "Gothic/Doom/Death Metal",
+        "country": "Russia",
+        "band": "...of Drowning Heaven",
+        "preparedBandName": "...of%2BDrowning%20Heaven",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...of_Drowning_Heaven/3540375137\">...of Drowning Heaven</a>  <!-- 1 -->",
+            "Gothic/Doom/Death Metal",
+            "Russia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...of_the_Horizon/3540482042",
+        "id": "3540482042",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...of_the_Horizon/3540482042\">...of the Horizon</a>  <!-- 1 -->",
+        "genre": "Psychedelic Doom Metal",
+        "country": "United States",
+        "band": "...of the Horizon",
+        "preparedBandName": "...of%2Bthe%20Horizon",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...of_the_Horizon/3540482042\">...of the Horizon</a>  <!-- 1 -->",
+            "Psychedelic Doom Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...of_the_Human_Condition/14744",
+        "id": "14744",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...of_the_Human_Condition/14744\">...of the Human Condition</a>  <!-- 1 -->",
+        "genre": "Melodic Death/Gothic Metal",
+        "country": "Australia",
+        "band": "...of the Human Condition",
+        "preparedBandName": "...of%2Bthe%20Human%20Condition",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...of_the_Human_Condition/14744\">...of the Human Condition</a>  <!-- 1 -->",
+            "Melodic Death/Gothic Metal",
+            "Australia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...on_the_Night/82136",
+        "id": "82136",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...on_the_Night/82136\">...on the Night</a>  <!-- 1 -->",
+        "genre": "Black/Death Metal",
+        "country": "Poland",
+        "band": "...on the Night",
+        "preparedBandName": "...on%2Bthe%20Night",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...on_the_Night/82136\">...on the Night</a>  <!-- 1 -->",
+            "Black/Death Metal",
+            "Poland"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...One%2C_Thousand_Children.../3540519507",
+        "id": "3540519507",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...One%2C_Thousand_Children.../3540519507\">...One, Thousand Children...</a>  <!-- 1 -->",
+        "genre": "Black Metal",
+        "country": "Italy",
+        "band": "...One, Thousand Children...",
+        "preparedBandName": "...One%2C%2BThousand%20Children...",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...One%2C_Thousand_Children.../3540519507\">...One, Thousand Children...</a>  <!-- 1 -->",
+            "Black Metal",
+            "Italy"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...Sick_of_Life/3540411185",
+        "id": "3540411185",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...Sick_of_Life/3540411185\">...Sick of Life</a>  <!-- 1 -->",
+        "genre": "Black Metal",
+        "country": "International",
+        "band": "...Sick of Life",
+        "preparedBandName": "...Sick%2Bof%20Life",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...Sick_of_Life/3540411185\">...Sick of Life</a>  <!-- 1 -->",
+            "Black Metal",
+            "International"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...Under_a_Full_Moon/3540427593",
+        "id": "3540427593",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...Under_a_Full_Moon/3540427593\">...Under a Full Moon</a>  <!-- 1 -->",
+        "genre": "Black/Doom Metal",
+        "country": "United States",
+        "band": "...Under a Full Moon",
+        "preparedBandName": "...Under%2Ba%20Full%20Moon",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...Under_a_Full_Moon/3540427593\">...Under a Full Moon</a>  <!-- 1 -->",
+            "Black/Doom Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/...When_the_Darkness_Weeps/3540481397",
+        "id": "3540481397",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/...When_the_Darkness_Weeps/3540481397\">...When the Darkness Weeps</a>  <!-- 1 -->",
+        "genre": "Depressive Black Metal",
+        "country": "Australia",
+        "band": "...When the Darkness Weeps",
+        "preparedBandName": "...When%2Bthe%20Darkness%20Weeps",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/...When_the_Darkness_Weeps/3540481397\">...When the Darkness Weeps</a>  <!-- 1 -->",
+            "Depressive Black Metal",
+            "Australia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/.357/58217",
+        "id": "58217",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/.357/58217\">.357</a>  <!-- 1 -->",
+        "genre": "Black Metal/Grindcore",
+        "country": "United States",
+        "band": ".357",
+        "preparedBandName": ".357",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/.357/58217\">.357</a>  <!-- 1 -->",
+            "Black Metal/Grindcore",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/.357_Homicide/3540475735",
+        "id": "3540475735",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/.357_Homicide/3540475735\">.357 Homicide</a>  <!-- 1 -->",
+        "genre": "Slam/Brutal Death Metal",
+        "country": "United Kingdom",
+        "band": ".357 Homicide",
+        "preparedBandName": ".357%2BHomicide",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/.357_Homicide/3540475735\">.357 Homicide</a>  <!-- 1 -->",
+            "Slam/Brutal Death Metal",
+            "United Kingdom"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/.357_Soundsystem/124935",
+        "id": "124935",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/.357_Soundsystem/124935\">.357 Soundsystem</a>  <!-- 1 -->",
+        "genre": "Death/Groove Metal, Death 'n' Roll",
+        "country": "Finland",
+        "band": ".357 Soundsystem",
+        "preparedBandName": ".357%2BSoundsystem",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/.357_Soundsystem/124935\">.357 Soundsystem</a>  <!-- 1 -->",
+            "Death/Groove Metal, Death 'n' Roll",
+            "Finland"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/.44_Caliber_Killers/98872",
+        "id": "98872",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/.44_Caliber_Killers/98872\">.44 Caliber Killers</a>  <!-- 1 -->",
+        "genre": "Thrash Metal/Punk/Crossover",
+        "country": "United States",
+        "band": ".44 Caliber Killers",
+        "preparedBandName": ".44%2BCaliber%20Killers",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/.44_Caliber_Killers/98872\">.44 Caliber Killers</a>  <!-- 1 -->",
+            "Thrash Metal/Punk/Crossover",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/.50Cal_Facial_Fracture/3540488235",
+        "id": "3540488235",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/.50Cal_Facial_Fracture/3540488235\">.50Cal Facial Fracture</a>  <!-- 1 -->",
+        "genre": "Slam/Brutal Death Metal",
+        "country": "United States",
+        "band": ".50Cal Facial Fracture",
+        "preparedBandName": ".50Cal%2BFacial%20Fracture",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/.50Cal_Facial_Fracture/3540488235\">.50Cal Facial Fracture</a>  <!-- 1 -->",
+            "Slam/Brutal Death Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/.Deathbefore/3540533248",
+        "id": "3540533248",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/.Deathbefore/3540533248\">.Deathbefore</a>  <!-- 1 -->",
+        "genre": "Depressive Black Metal",
+        "country": "Russia",
+        "band": ".Deathbefore",
+        "preparedBandName": ".Deathbefore",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/.Deathbefore/3540533248\">.Deathbefore</a>  <!-- 1 -->",
+            "Depressive Black Metal",
+            "Russia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/.F.O.A.D./3540337513",
+        "id": "3540337513",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/.F.O.A.D./3540337513\">.F.O.A.D.</a>  <!-- 1 -->",
+        "genre": "Death Metal",
+        "country": "France",
+        "band": ".F.O.A.D.",
+        "preparedBandName": ".F.O.A.D.",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/.F.O.A.D./3540337513\">.F.O.A.D.</a>  <!-- 1 -->",
+            "Death Metal",
+            "France"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/.mt/3540465411",
+        "id": "3540465411",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/.mt/3540465411\">.mt</a>  <!-- 1 -->",
+        "genre": "Post-Black Metal",
+        "country": "Brazil",
+        "band": ".mt",
+        "preparedBandName": ".mt",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/.mt/3540465411\">.mt</a>  <!-- 1 -->",
+            "Post-Black Metal",
+            "Brazil"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/.Nema/3540332807",
+        "id": "3540332807",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/.Nema/3540332807\">.Nema</a>  <!-- 1 -->",
+        "genre": "Black Metal/Hardcore/Crust Punk",
+        "country": "United States",
+        "band": ".Nema",
+        "preparedBandName": ".Nema",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/.Nema/3540332807\">.Nema</a>  <!-- 1 -->",
+            "Black Metal/Hardcore/Crust Punk",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/.springofdrownedpanda./3540380044",
+        "id": "3540380044",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/.springofdrownedpanda./3540380044\">.springofdrownedpanda.</a>  <!-- 1 -->",
+        "genre": "Sludge/Doom Metal",
+        "country": "United States",
+        "band": ".springofdrownedpanda.",
+        "preparedBandName": ".springofdrownedpanda.",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/.springofdrownedpanda./3540380044\">.springofdrownedpanda.</a>  <!-- 1 -->",
+            "Sludge/Doom Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/0/3540384774",
+        "id": "3540384774",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/0/3540384774\">0</a>  <!-- 1 -->",
+        "genre": "Depressive Black/Doom Metal",
+        "country": "Iceland",
+        "band": "0",
+        "preparedBandName": "0",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/0/3540384774\">0</a>  <!-- 1 -->",
+            "Depressive Black/Doom Metal",
+            "Iceland"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/0_Existence/3540534191",
+        "id": "3540534191",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/0_Existence/3540534191\">0 Existence</a>  <!-- 1 -->",
+        "genre": "Depressive Black Metal",
+        "country": "Mexico",
+        "band": "0 Existence",
+        "preparedBandName": "0%2BExistence",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/0_Existence/3540534191\">0 Existence</a>  <!-- 1 -->",
+            "Depressive Black Metal",
+            "Mexico"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/0_X_%C3%AD_S_T/3540304450",
+        "id": "3540304450",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/0_X_%C3%AD_S_T/3540304450\">0 X í S T</a>  <!-- 1 -->",
+        "genre": "Blackened Doom Metal",
+        "country": "Finland",
+        "band": "0 X í S T",
+        "preparedBandName": "0%2BX%20%C3%AD%20S%20T",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/0_X_%C3%AD_S_T/3540304450\">0 X í S T</a>  <!-- 1 -->",
+            "Blackened Doom Metal",
+            "Finland"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/0_Zone/3540398489",
+        "id": "3540398489",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/0_Zone/3540398489\">0 Zone</a>  <!-- 1 -->",
+        "genre": "Death/Thrash Metal",
+        "country": "Greece",
+        "band": "0 Zone",
+        "preparedBandName": "0%2BZone",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/0_Zone/3540398489\">0 Zone</a>  <!-- 1 -->",
+            "Death/Thrash Metal",
+            "Greece"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/0%25_Hate/3540476464",
+        "id": "3540476464",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/0%25_Hate/3540476464\">0% Hate</a>  <!-- 1 -->",
+        "genre": "Technical Death Metal",
+        "country": "United States",
+        "band": "0% Hate",
+        "preparedBandName": "0%25%2BHate",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/0%25_Hate/3540476464\">0% Hate</a>  <!-- 1 -->",
+            "Technical Death Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/0-Nun/3540471393",
+        "id": "3540471393",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/0-Nun/3540471393\">0-Nun</a>  <!-- 1 -->",
+        "genre": "Atmospheric Black Metal",
+        "country": "Brazil",
+        "band": "0-Nun",
+        "preparedBandName": "0-Nun",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/0-Nun/3540471393\">0-Nun</a>  <!-- 1 -->",
+            "Atmospheric Black Metal",
+            "Brazil"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/00/3540480431",
+        "id": "3540480431",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/00/3540480431\">00</a>  <!-- 1 -->",
+        "genre": "Stoner/Doom Metal/Rock",
+        "country": "United States",
+        "band": "00",
+        "preparedBandName": "00",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/00/3540480431\">00</a>  <!-- 1 -->",
+            "Stoner/Doom Metal/Rock",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/00y_18/3540532376",
+        "id": "3540532376",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/00y_18/3540532376\">00y 18</a>  <!-- 1 -->",
+        "genre": "Sludge/Post-Metal",
+        "country": "Austria",
+        "band": "00y 18",
+        "preparedBandName": "00y%2B18",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/00y_18/3540532376\">00y 18</a>  <!-- 1 -->",
+            "Sludge/Post-Metal",
+            "Austria"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/01101111011101100110111001101001/3540434066",
+        "id": "3540434066",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/01101111011101100110111001101001/3540434066\">01101111011101100110111001101001</a>  <!-- 1 -->",
+        "genre": "Brutal Death Metal",
+        "country": "Argentina",
+        "band": "01101111011101100110111001101001",
+        "preparedBandName": "01101111011101100110111001101001",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/01101111011101100110111001101001/3540434066\">01101111011101100110111001101001</a>  <!-- 1 -->",
+            "Brutal Death Metal",
+            "Argentina"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/049/3540494814",
+        "id": "3540494814",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/049/3540494814\">049</a>  <!-- 1 -->",
+        "genre": "Heavy Metal",
+        "country": "Italy",
+        "band": "049",
+        "preparedBandName": "049",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/049/3540494814\">049</a>  <!-- 1 -->",
+            "Heavy Metal",
+            "Italy"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/0mega/3540541030",
+        "id": "3540541030",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/0mega/3540541030\">0mega</a>  <!-- 1 -->",
+        "genre": "Groove/Thrash Metal",
+        "country": "Germany",
+        "band": "0mega",
+        "preparedBandName": "0mega",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/0mega/3540541030\">0mega</a>  <!-- 1 -->",
+            "Groove/Thrash Metal",
+            "Germany"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/0N0/3540325569",
+        "id": "3540325569",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/0N0/3540325569\">0N0</a>  <!-- 1 -->",
+        "genre": "Experimental Industrial Doom/Death Metal",
+        "country": "Slovakia",
+        "band": "0N0",
+        "preparedBandName": "0N0",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/0N0/3540325569\">0N0</a>  <!-- 1 -->",
+            "Experimental Industrial Doom/Death Metal",
+            "Slovakia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1_Body_6_Graves/3540511589",
+        "id": "3540511589",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1_Body_6_Graves/3540511589\">1 Body 6 Graves</a>  <!-- 1 -->",
+        "genre": "Death Metal",
+        "country": "United States",
+        "band": "1 Body 6 Graves",
+        "preparedBandName": "1%2BBody%206%20Graves",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1_Body_6_Graves/3540511589\">1 Body 6 Graves</a>  <!-- 1 -->",
+            "Death Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1_Inch_Bullet/3540537651",
+        "id": "3540537651",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1_Inch_Bullet/3540537651\">1 Inch Bullet</a>  <!-- 1 -->",
+        "genre": "Industrial/Death Metal/Metalcore",
+        "country": "Germany",
+        "band": "1 Inch Bullet",
+        "preparedBandName": "1%2BInch%20Bullet",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1_Inch_Bullet/3540537651\">1 Inch Bullet</a>  <!-- 1 -->",
+            "Industrial/Death Metal/Metalcore",
+            "Germany"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1_Shot_Kill/70401",
+        "id": "70401",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1_Shot_Kill/70401\">1 Shot Kill</a>  <!-- 1 -->",
+        "genre": "Death/Groove Metal",
+        "country": "Australia",
+        "band": "1 Shot Kill",
+        "preparedBandName": "1%2BShot%20Kill",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1_Shot_Kill/70401\">1 Shot Kill</a>  <!-- 1 -->",
+            "Death/Groove Metal",
+            "Australia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1%2C000%2C000_Holy_Mothers/3540531187",
+        "id": "3540531187",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1%2C000%2C000_Holy_Mothers/3540531187\">1,000,000 Holy Mothers</a>  <!-- 1 -->",
+        "genre": "Sludge/Stoner/Doom Metal",
+        "country": "United Kingdom",
+        "band": "1,000,000 Holy Mothers",
+        "preparedBandName": "1%2C000%2C000%2BHoly%20Mothers",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1%2C000%2C000_Holy_Mothers/3540531187\">1,000,000 Holy Mothers</a>  <!-- 1 -->",
+            "Sludge/Stoner/Doom Metal",
+            "United Kingdom"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/10_Kingdoms/66551",
+        "id": "66551",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/10_Kingdoms/66551\">10 Kingdoms</a>  <!-- 1 -->",
+        "genre": "Thrash/Heavy Metal",
+        "country": "United States",
+        "band": "10 Kingdoms",
+        "preparedBandName": "10%2BKingdoms",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/10_Kingdoms/66551\">10 Kingdoms</a>  <!-- 1 -->",
+            "Thrash/Heavy Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/10_Plagues/3540509745",
+        "id": "3540509745",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/10_Plagues/3540509745\">10 Plagues</a>  <!-- 1 -->",
+        "genre": "Death/Black Metal",
+        "country": "United Kingdom",
+        "band": "10 Plagues",
+        "preparedBandName": "10%2BPlagues",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/10_Plagues/3540509745\">10 Plagues</a>  <!-- 1 -->",
+            "Death/Black Metal",
+            "United Kingdom"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/10_to_the_Chest/3540522142",
+        "id": "3540522142",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/10_to_the_Chest/3540522142\">10 to the Chest</a>  <!-- 1 -->",
+        "genre": "Death Metal/Hardcore",
+        "country": "United States",
+        "band": "10 to the Chest",
+        "preparedBandName": "10%2Bto%20the%20Chest",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/10_to_the_Chest/3540522142\">10 to the Chest</a>  <!-- 1 -->",
+            "Death Metal/Hardcore",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/10%24_Head/93854",
+        "id": "93854",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/10%24_Head/93854\">10$ Head</a>  <!-- 1 -->",
+        "genre": "Death/Thrash Metal",
+        "country": "United Kingdom",
+        "band": "10$ Head",
+        "preparedBandName": "10%24%2BHead",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/10%24_Head/93854\">10$ Head</a>  <!-- 1 -->",
+            "Death/Thrash Metal",
+            "United Kingdom"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/10%2C000_Years/3540470669",
+        "id": "3540470669",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/10%2C000_Years/3540470669\">10,000 Years</a>  <!-- 1 -->",
+        "genre": "Stoner Metal",
+        "country": "Sweden",
+        "band": "10,000 Years",
+        "preparedBandName": "10%2C000%2BYears",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/10%2C000_Years/3540470669\">10,000 Years</a>  <!-- 1 -->",
+            "Stoner Metal",
+            "Sweden"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/10-50_Nightmare/3540541698",
+        "id": "3540541698",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/10-50_Nightmare/3540541698\">10-50 Nightmare</a>  <!-- 1 -->",
+        "genre": "Death/Groove Metal",
+        "country": "United States",
+        "band": "10-50 Nightmare",
+        "preparedBandName": "10-50%2BNightmare",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/10-50_Nightmare/3540541698\">10-50 Nightmare</a>  <!-- 1 -->",
+            "Death/Groove Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/10-67_P.D.O.A./88666",
+        "id": "88666",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/10-67_P.D.O.A./88666\">10-67 P.D.O.A.</a>  <!-- 1 -->",
+        "genre": "Heavy Metal",
+        "country": "United States",
+        "band": "10-67 P.D.O.A.",
+        "preparedBandName": "10-67%2BP.D.O.A.",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/10-67_P.D.O.A./88666\">10-67 P.D.O.A.</a>  <!-- 1 -->",
+            "Heavy Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/10.000_km%C2%B2_gegen_die_Zeit/3540395576",
+        "id": "3540395576",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/10.000_km%C2%B2_gegen_die_Zeit/3540395576\">10.000 km² gegen die Zeit</a>  <!-- 1 -->",
+        "genre": "Stoner/Doom Metal/Rock",
+        "country": "Germany",
+        "band": "10.000 km² gegen die Zeit",
+        "preparedBandName": "10.000%2Bkm%C2%B2%20gegen%20die%20Zeit",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/10.000_km%C2%B2_gegen_die_Zeit/3540395576\">10.000 km² gegen die Zeit</a>  <!-- 1 -->",
+            "Stoner/Doom Metal/Rock",
+            "Germany"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/100_Dogmas/3540447570",
+        "id": "3540447570",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/100_Dogmas/3540447570\">100 Dogmas</a>  <!-- 1 -->",
+        "genre": "Groove Metal/Hard Rock",
+        "country": "Brazil",
+        "band": "100 Dogmas",
+        "preparedBandName": "100%2BDogmas",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/100_Dogmas/3540447570\">100 Dogmas</a>  <!-- 1 -->",
+            "Groove Metal/Hard Rock",
+            "Brazil"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/100_Knives_Inside/3540260920",
+        "id": "3540260920",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/100_Knives_Inside/3540260920\">100 Knives Inside</a>  <!-- 1 -->",
+        "genre": "Progressive Death Metal",
+        "country": "Denmark",
+        "band": "100 Knives Inside",
+        "preparedBandName": "100%2BKnives%20Inside",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/100_Knives_Inside/3540260920\">100 Knives Inside</a>  <!-- 1 -->",
+            "Progressive Death Metal",
+            "Denmark"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/100_Remords/3540474085",
+        "id": "3540474085",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/100_Remords/3540474085\">100 Remords</a>  <!-- 1 -->",
+        "genre": "Symphonic Power/Heavy Metal",
+        "country": "Canada",
+        "band": "100 Remords",
+        "preparedBandName": "100%2BRemords",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/100_Remords/3540474085\">100 Remords</a>  <!-- 1 -->",
+            "Symphonic Power/Heavy Metal",
+            "Canada"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/100_Slain/3540266645",
+        "id": "3540266645",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/100_Slain/3540266645\">100 Slain</a>  <!-- 1 -->",
+        "genre": "Thrash Metal",
+        "country": "Spain",
+        "band": "100 Slain",
+        "preparedBandName": "100%2BSlain",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/100_Slain/3540266645\">100 Slain</a>  <!-- 1 -->",
+            "Thrash Metal",
+            "Spain"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/100_Suns/87700",
+        "id": "87700",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/100_Suns/87700\">100 Suns</a>  <!-- 1 -->",
+        "genre": "Death Metal",
+        "country": "United States",
+        "band": "100 Suns",
+        "preparedBandName": "100%2BSuns",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/100_Suns/87700\">100 Suns</a>  <!-- 1 -->",
+            "Death Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/100_Years_War/3540475321",
+        "id": "3540475321",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/100_Years_War/3540475321\">100 Years War</a>  <!-- 1 -->",
+        "genre": "Death Metal/Crust",
+        "country": "Australia",
+        "band": "100 Years War",
+        "preparedBandName": "100%2BYears%20War",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/100_Years_War/3540475321\">100 Years War</a>  <!-- 1 -->",
+            "Death Metal/Crust",
+            "Australia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1000_A.D./81844",
+        "id": "81844",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1000_A.D./81844\">1000 A.D.</a>  <!-- 1 -->",
+        "genre": "Drone/Sludge Metal",
+        "country": "United States",
+        "band": "1000 A.D.",
+        "preparedBandName": "1000%2BA.D.",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1000_A.D./81844\">1000 A.D.</a>  <!-- 1 -->",
+            "Drone/Sludge Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1000_Bombs/3540373729",
+        "id": "3540373729",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1000_Bombs/3540373729\">1000 Bombs</a>  <!-- 1 -->",
+        "genre": "Thrash Metal",
+        "country": "Czechia",
+        "band": "1000 Bombs",
+        "preparedBandName": "1000%2BBombs",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1000_Bombs/3540373729\">1000 Bombs</a>  <!-- 1 -->",
+            "Thrash Metal",
+            "Czechia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1000_Bone_Cylinder_Explosion/3540495602",
+        "id": "3540495602",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1000_Bone_Cylinder_Explosion/3540495602\">1000 Bone Cylinder Explosion</a>  <!-- 1 -->",
+        "genre": "Avant-garde Black/Speed Metal",
+        "country": "United States",
+        "band": "1000 Bone Cylinder Explosion",
+        "preparedBandName": "1000%2BBone%20Cylinder%20Explosion",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1000_Bone_Cylinder_Explosion/3540495602\">1000 Bone Cylinder Explosion</a>  <!-- 1 -->",
+            "Avant-garde Black/Speed Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1000_Foot_Bong/3540527248",
+        "id": "3540527248",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1000_Foot_Bong/3540527248\">1000 Foot Bong</a>  <!-- 1 -->",
+        "genre": "Stoner/Sludge/Doom Metal",
+        "country": "United States",
+        "band": "1000 Foot Bong",
+        "preparedBandName": "1000%2BFoot%20Bong",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1000_Foot_Bong/3540527248\">1000 Foot Bong</a>  <!-- 1 -->",
+            "Stoner/Sludge/Doom Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1000_Funerals/3540326834",
+        "id": "3540326834",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1000_Funerals/3540326834\">1000 Funerals</a>  <!-- 1 -->",
+        "genre": "Funeral Doom/Death Metal/Ambient",
+        "country": "Iran",
+        "band": "1000 Funerals",
+        "preparedBandName": "1000%2BFunerals",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1000_Funerals/3540326834\">1000 Funerals</a>  <!-- 1 -->",
+            "Funeral Doom/Death Metal/Ambient",
+            "Iran"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1000_Kadaveres/3540413759",
+        "id": "3540413759",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1000_Kadaveres/3540413759\">1000 Kadaveres</a>  <!-- 1 -->",
+        "genre": "Brutal Death Metal/Goregrind",
+        "country": "Chile",
+        "band": "1000 Kadaveres",
+        "preparedBandName": "1000%2BKadaveres",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1000_Kadaveres/3540413759\">1000 Kadaveres</a>  <!-- 1 -->",
+            "Brutal Death Metal/Goregrind",
+            "Chile"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1000_Odios/122684",
+        "id": "122684",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1000_Odios/122684\">1000 Odios</a>  <!-- 1 -->",
+        "genre": "Thrash/Melodic Death Metal",
+        "country": "Argentina",
+        "band": "1000 Odios",
+        "preparedBandName": "1000%2BOdios",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1000_Odios/122684\">1000 Odios</a>  <!-- 1 -->",
+            "Thrash/Melodic Death Metal",
+            "Argentina"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1000_Rooms/3540514731",
+        "id": "3540514731",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1000_Rooms/3540514731\">1000 Rooms</a>  <!-- 1 -->",
+        "genre": "Progressive Metal",
+        "country": "Canada",
+        "band": "1000 Rooms",
+        "preparedBandName": "1000%2BRooms",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1000_Rooms/3540514731\">1000 Rooms</a>  <!-- 1 -->",
+            "Progressive Metal",
+            "Canada"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1000_Scars/3540531619",
+        "id": "3540531619",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1000_Scars/3540531619\">1000 Scars</a>  <!-- 1 -->",
+        "genre": "Thrash Metal/Hardcore Punk, Death Metal",
+        "country": "United Kingdom",
+        "band": "1000 Scars",
+        "preparedBandName": "1000%2BScars",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1000_Scars/3540531619\">1000 Scars</a>  <!-- 1 -->",
+            "Thrash Metal/Hardcore Punk, Death Metal",
+            "United Kingdom"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1000_Sins/112675",
+        "id": "112675",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1000_Sins/112675\">1000 Sins</a>  <!-- 1 -->",
+        "genre": "Metalcore",
+        "country": "United Kingdom",
+        "band": "1000 Sins",
+        "preparedBandName": "1000%2BSins",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1000_Sins/112675\">1000 Sins</a>  <!-- 1 -->",
+            "Metalcore",
+            "United Kingdom"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1000_Vierges/129655",
+        "id": "129655",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1000_Vierges/129655\">1000 Vierges</a>  <!-- 1 -->",
+        "genre": "Sludge/Doom Metal",
+        "country": "France",
+        "band": "1000 Vierges",
+        "preparedBandName": "1000%2BVierges",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1000_Vierges/129655\">1000 Vierges</a>  <!-- 1 -->",
+            "Sludge/Doom Metal",
+            "France"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1000_Yard_Stare/3540314400",
+        "id": "3540314400",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1000_Yard_Stare/3540314400\">1000 Yard Stare</a>  <!-- 1 -->",
+        "genre": "Death/Groove Metal (early); Sludge/Doom/Death Metal (later)",
+        "country": "United States",
+        "band": "1000 Yard Stare",
+        "preparedBandName": "1000%2BYard%20Stare",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1000_Yard_Stare/3540314400\">1000 Yard Stare</a>  <!-- 1 -->",
+            "Death/Groove Metal (early); Sludge/Doom/Death Metal (later)",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/100000_Tonnen_Kruppstahl/3540313198",
+        "id": "3540313198",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/100000_Tonnen_Kruppstahl/3540313198\">100000 Tonnen Kruppstahl</a>  <!-- 1 -->",
+        "genre": "Grindcore/Powerviolence (early); Sludge/Doom Metal (later)",
+        "country": "Germany",
+        "band": "100000 Tonnen Kruppstahl",
+        "preparedBandName": "100000%2BTonnen%20Kruppstahl",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/100000_Tonnen_Kruppstahl/3540313198\">100000 Tonnen Kruppstahl</a>  <!-- 1 -->",
+            "Grindcore/Powerviolence (early); Sludge/Doom Metal (later)",
+            "Germany"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1000Dead/3540425687",
+        "id": "3540425687",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1000Dead/3540425687\">1000Dead</a>  <!-- 1 -->",
+        "genre": "Metalcore/Thrash/Groove Metal",
+        "country": "Greece",
+        "band": "1000Dead",
+        "preparedBandName": "1000Dead",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1000Dead/3540425687\">1000Dead</a>  <!-- 1 -->",
+            "Metalcore/Thrash/Groove Metal",
+            "Greece"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1016/3540540151",
+        "id": "3540540151",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1016/3540540151\">1016</a>  <!-- 1 -->",
+        "genre": "Stoner/Southern Metal/Rock",
+        "country": "United States",
+        "band": "1016",
+        "preparedBandName": "1016",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1016/3540540151\">1016</a>  <!-- 1 -->",
+            "Stoner/Southern Metal/Rock",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1024/3540532823",
+        "id": "3540532823",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1024/3540532823\">1024</a>  <!-- 1 -->",
+        "genre": "Blackened Deathcore",
+        "country": "United Kingdom",
+        "band": "1024",
+        "preparedBandName": "1024",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1024/3540532823\">1024</a>  <!-- 1 -->",
+            "Blackened Deathcore",
+            "United Kingdom"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1028/3540458508",
+        "id": "3540458508",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1028/3540458508\">1028</a>  <!-- 1 -->",
+        "genre": "Blackened Death Metal",
+        "country": "Ecuador",
+        "band": "1028",
+        "preparedBandName": "1028",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1028/3540458508\">1028</a>  <!-- 1 -->",
+            "Blackened Death Metal",
+            "Ecuador"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/107_Pasos/68859",
+        "id": "68859",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/107_Pasos/68859\">107 Pasos</a>  <!-- 1 -->",
+        "genre": "Heavy Metal",
+        "country": "Colombia",
+        "band": "107 Pasos",
+        "preparedBandName": "107%2BPasos",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/107_Pasos/68859\">107 Pasos</a>  <!-- 1 -->",
+            "Heavy Metal",
+            "Colombia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1080/38703",
+        "id": "38703",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1080/38703\">1080</a>  <!-- 1 -->",
+        "genre": "Groove/Thrash Metal",
+        "country": "United States",
+        "band": "1080",
+        "preparedBandName": "1080",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1080/38703\">1080</a>  <!-- 1 -->",
+            "Groove/Thrash Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/10%3A13/3540452035",
+        "id": "3540452035",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/10%3A13/3540452035\">10:13</a>  <!-- 1 -->",
+        "genre": "Psychedelic/Experimental Black Metal",
+        "country": "United States",
+        "band": "10:13",
+        "preparedBandName": "10%3A13",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/10%3A13/3540452035\">10:13</a>  <!-- 1 -->",
+            "Psychedelic/Experimental Black Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/10Eyes/33414",
+        "id": "33414",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/10Eyes/33414\">10Eyes</a>  <!-- 1 -->",
+        "genre": "Power Metal",
+        "country": "Germany",
+        "band": "10Eyes",
+        "preparedBandName": "10Eyes",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/10Eyes/33414\">10Eyes</a>  <!-- 1 -->",
+            "Power Metal",
+            "Germany"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/11_Paranoias/3540366703",
+        "id": "3540366703",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/11_Paranoias/3540366703\">11 Paranoias</a>  <!-- 1 -->",
+        "genre": "Sludge/Doom Metal",
+        "country": "United Kingdom",
+        "band": "11 Paranoias",
+        "preparedBandName": "11%2BParanoias",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/11_Paranoias/3540366703\">11 Paranoias</a>  <!-- 1 -->",
+            "Sludge/Doom Metal",
+            "United Kingdom"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/11034/3540477583",
+        "id": "3540477583",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/11034/3540477583\">11034</a>  <!-- 1 -->",
+        "genre": "Black Metal",
+        "country": "Germany",
+        "band": "11034",
+        "preparedBandName": "11034",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/11034/3540477583\">11034</a>  <!-- 1 -->",
+            "Black Metal",
+            "Germany"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1134/3540504948",
+        "id": "3540504948",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1134/3540504948\">1134</a>  <!-- 1 -->",
+        "genre": "Heavy/Groove/Thrash Metal",
+        "country": "United States",
+        "band": "1134",
+        "preparedBandName": "1134",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1134/3540504948\">1134</a>  <!-- 1 -->",
+            "Heavy/Groove/Thrash Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1134/76862",
+        "id": "76862",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1134/76862\">1134</a>  <!-- 1 -->",
+        "genre": "Thrash/Groove Metal",
+        "country": "United States",
+        "band": "1134",
+        "preparedBandName": "1134",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1134/76862\">1134</a>  <!-- 1 -->",
+            "Thrash/Groove Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/11%3A11/3540317975",
+        "id": "3540317975",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/11%3A11/3540317975\">11:11</a>  <!-- 1 -->",
+        "genre": "Heavy/Thrash Metal",
+        "country": "United States",
+        "band": "11:11",
+        "preparedBandName": "11%3A11",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/11%3A11/3540317975\">11:11</a>  <!-- 1 -->",
+            "Heavy/Thrash Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/11%3A34/96094",
+        "id": "96094",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/11%3A34/96094\">11:34</a>  <!-- 1 -->",
+        "genre": "Death/Thrash Metal",
+        "country": "United States",
+        "band": "11:34",
+        "preparedBandName": "11%3A34",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/11%3A34/96094\">11:34</a>  <!-- 1 -->",
+            "Death/Thrash Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/11redearth/3540447569",
+        "id": "3540447569",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/11redearth/3540447569\">11redearth</a>  <!-- 1 -->",
+        "genre": "Experimental/Psychedelic Doom Metal",
+        "country": "Germany",
+        "band": "11redearth",
+        "preparedBandName": "11redearth",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/11redearth/3540447569\">11redearth</a>  <!-- 1 -->",
+            "Experimental/Psychedelic Doom Metal",
+            "Germany"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/11th_Dimension/3540382000",
+        "id": "3540382000",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/11th_Dimension/3540382000\">11th Dimension</a>  <!-- 1 -->",
+        "genre": "Progressive Metal",
+        "country": "Portugal",
+        "band": "11th Dimension",
+        "preparedBandName": "11th%2BDimension",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/11th_Dimension/3540382000\">11th Dimension</a>  <!-- 1 -->",
+            "Progressive Metal",
+            "Portugal"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/11th_Hour/3540478621",
+        "id": "3540478621",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/11th_Hour/3540478621\">11th Hour</a>  <!-- 1 -->",
+        "genre": "Melodic Metalcore",
+        "country": "Sweden",
+        "band": "11th Hour",
+        "preparedBandName": "11th%2BHour",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/11th_Hour/3540478621\">11th Hour</a>  <!-- 1 -->",
+            "Melodic Metalcore",
+            "Sweden"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/11th_Plague/3540439269",
+        "id": "3540439269",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/11th_Plague/3540439269\">11th Plague</a>  <!-- 1 -->",
+        "genre": "Groove/Thrash Metal",
+        "country": "United States",
+        "band": "11th Plague",
+        "preparedBandName": "11th%2BPlague",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/11th_Plague/3540439269\">11th Plague</a>  <!-- 1 -->",
+            "Groove/Thrash Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Days_of_Anarchy/94580",
+        "id": "94580",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Days_of_Anarchy/94580\">12 Days of Anarchy</a>  <!-- 1 -->",
+        "genre": "Death Metal",
+        "country": "United States",
+        "band": "12 Days of Anarchy",
+        "preparedBandName": "12%2BDays%20of%20Anarchy",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Days_of_Anarchy/94580\">12 Days of Anarchy</a>  <!-- 1 -->",
+            "Death Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Days_Straight/3540472985",
+        "id": "3540472985",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Days_Straight/3540472985\">12 Days Straight</a>  <!-- 1 -->",
+        "genre": "Groove Metal",
+        "country": "United States",
+        "band": "12 Days Straight",
+        "preparedBandName": "12%2BDays%20Straight",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Days_Straight/3540472985\">12 Days Straight</a>  <!-- 1 -->",
+            "Groove Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Degrees_of_Saturation/3540510701",
+        "id": "3540510701",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Degrees_of_Saturation/3540510701\">12 Degrees of Saturation</a>  <!-- 1 -->",
+        "genre": "Heavy Metal/Hard Rock",
+        "country": "Brazil",
+        "band": "12 Degrees of Saturation",
+        "preparedBandName": "12%2BDegrees%20of%20Saturation",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Degrees_of_Saturation/3540510701\">12 Degrees of Saturation</a>  <!-- 1 -->",
+            "Heavy Metal/Hard Rock",
+            "Brazil"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Eyes/97701",
+        "id": "97701",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Eyes/97701\">12 Eyes</a>  <!-- 1 -->",
+        "genre": "Sludge Metal",
+        "country": "United States",
+        "band": "12 Eyes",
+        "preparedBandName": "12%2BEyes",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Eyes/97701\">12 Eyes</a>  <!-- 1 -->",
+            "Sludge Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Gauge/3540473187",
+        "id": "3540473187",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Gauge/3540473187\">12 Gauge</a>  <!-- 1 -->",
+        "genre": "Thrash/Groove Metal",
+        "country": "Ireland",
+        "band": "12 Gauge",
+        "preparedBandName": "12%2BGauge",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Gauge/3540473187\">12 Gauge</a>  <!-- 1 -->",
+            "Thrash/Groove Metal",
+            "Ireland"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Gauge/120735",
+        "id": "120735",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Gauge/120735\">12 Gauge</a>  <!-- 1 -->",
+        "genre": "Thrash/Groove Metal/Metalcore",
+        "country": "Netherlands",
+        "band": "12 Gauge",
+        "preparedBandName": "12%2BGauge",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Gauge/120735\">12 Gauge</a>  <!-- 1 -->",
+            "Thrash/Groove Metal/Metalcore",
+            "Netherlands"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Gauge_Dead/57334",
+        "id": "57334",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Gauge_Dead/57334\">12 Gauge Dead</a>  <!-- 1 -->",
+        "genre": "Death/Thrash Metal",
+        "country": "Sweden",
+        "band": "12 Gauge Dead",
+        "preparedBandName": "12%2BGauge%20Dead",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Gauge_Dead/57334\">12 Gauge Dead</a>  <!-- 1 -->",
+            "Death/Thrash Metal",
+            "Sweden"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Gauge_Massacre/3540460616",
+        "id": "3540460616",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Gauge_Massacre/3540460616\">12 Gauge Massacre</a>  <!-- 1 -->",
+        "genre": "Deathcore",
+        "country": "United States",
+        "band": "12 Gauge Massacre",
+        "preparedBandName": "12%2BGauge%20Massacre",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Gauge_Massacre/3540460616\">12 Gauge Massacre</a>  <!-- 1 -->",
+            "Deathcore",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Gauge_Outrage/3540394417",
+        "id": "3540394417",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Gauge_Outrage/3540394417\">12 Gauge Outrage</a>  <!-- 1 -->",
+        "genre": "Heavy/Thrash Metal",
+        "country": "Ireland",
+        "band": "12 Gauge Outrage",
+        "preparedBandName": "12%2BGauge%20Outrage",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Gauge_Outrage/3540394417\">12 Gauge Outrage</a>  <!-- 1 -->",
+            "Heavy/Thrash Metal",
+            "Ireland"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Gauge_Rampage/3540488714",
+        "id": "3540488714",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Gauge_Rampage/3540488714\">12 Gauge Rampage</a>  <!-- 1 -->",
+        "genre": "Brutal Death Metal/Grindcore",
+        "country": "Australia",
+        "band": "12 Gauge Rampage",
+        "preparedBandName": "12%2BGauge%20Rampage",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Gauge_Rampage/3540488714\">12 Gauge Rampage</a>  <!-- 1 -->",
+            "Brutal Death Metal/Grindcore",
+            "Australia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Pound_Pull/3540538211",
+        "id": "3540538211",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Pound_Pull/3540538211\">12 Pound Pull</a>  <!-- 1 -->",
+        "genre": "Death/Groove Metal",
+        "country": "United States",
+        "band": "12 Pound Pull",
+        "preparedBandName": "12%2BPound%20Pull",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Pound_Pull/3540538211\">12 Pound Pull</a>  <!-- 1 -->",
+            "Death/Groove Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Straight_Months_of_Winter/3540505228",
+        "id": "3540505228",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Straight_Months_of_Winter/3540505228\">12 Straight Months of Winter</a>  <!-- 1 -->",
+        "genre": "Deathcore",
+        "country": "Australia",
+        "band": "12 Straight Months of Winter",
+        "preparedBandName": "12%2BStraight%20Months%20of%20Winter",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Straight_Months_of_Winter/3540505228\">12 Straight Months of Winter</a>  <!-- 1 -->",
+            "Deathcore",
+            "Australia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Ton_Method/129676",
+        "id": "129676",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Ton_Method/129676\">12 Ton Method</a>  <!-- 1 -->",
+        "genre": "Technical Groove Metal",
+        "country": "United Kingdom",
+        "band": "12 Ton Method",
+        "preparedBandName": "12%2BTon%20Method",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Ton_Method/129676\">12 Ton Method</a>  <!-- 1 -->",
+            "Technical Groove Metal",
+            "United Kingdom"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Ton_Sledge/88309",
+        "id": "88309",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Ton_Sledge/88309\">12 Ton Sledge</a>  <!-- 1 -->",
+        "genre": "Thrash Metal",
+        "country": "United States",
+        "band": "12 Ton Sledge",
+        "preparedBandName": "12%2BTon%20Sledge",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Ton_Sledge/88309\">12 Ton Sledge</a>  <!-- 1 -->",
+            "Thrash Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12_Years/3540530825",
+        "id": "3540530825",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12_Years/3540530825\">12 Years</a>  <!-- 1 -->",
+        "genre": "Thrash Metal",
+        "country": "United States",
+        "band": "12 Years",
+        "preparedBandName": "12%2BYears",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12_Years/3540530825\">12 Years</a>  <!-- 1 -->",
+            "Thrash Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12.7/3540315455",
+        "id": "3540315455",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12.7/3540315455\">12.7</a>  <!-- 1 -->",
+        "genre": "Death/Thrash Metal",
+        "country": "France",
+        "band": "12.7",
+        "preparedBandName": "12.7",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12.7/3540315455\">12.7</a>  <!-- 1 -->",
+            "Death/Thrash Metal",
+            "France"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/120%3A155/3540522222",
+        "id": "3540522222",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/120%3A155/3540522222\">120:155</a>  <!-- 1 -->",
+        "genre": "Black/Doom Metal",
+        "country": "Germany",
+        "band": "120:155",
+        "preparedBandName": "120%3A155",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/120%3A155/3540522222\">120:155</a>  <!-- 1 -->",
+            "Black/Doom Metal",
+            "Germany"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/122_Stab_Wounds/5763",
+        "id": "5763",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/122_Stab_Wounds/5763\">122 Stab Wounds</a>  <!-- 1 -->",
+        "genre": "Black/Death Metal",
+        "country": "Norway",
+        "band": "122 Stab Wounds",
+        "preparedBandName": "122%2BStab%20Wounds",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/122_Stab_Wounds/5763\">122 Stab Wounds</a>  <!-- 1 -->",
+            "Black/Death Metal",
+            "Norway"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1228/3540528892",
+        "id": "3540528892",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1228/3540528892\">1228</a>  <!-- 1 -->",
+        "genre": "Black Metal",
+        "country": "United States",
+        "band": "1228",
+        "preparedBandName": "1228",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1228/3540528892\">1228</a>  <!-- 1 -->",
+            "Black Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12%3A06/3540413935",
+        "id": "3540413935",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12%3A06/3540413935\">12:06</a>  <!-- 1 -->",
+        "genre": "Thrash Metal/Crossover",
+        "country": "Spain",
+        "band": "12:06",
+        "preparedBandName": "12%3A06",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12%3A06/3540413935\">12:06</a>  <!-- 1 -->",
+            "Thrash Metal/Crossover",
+            "Spain"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12%3A06/12053",
+        "id": "12053",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12%3A06/12053\">12:06</a>  <!-- 1 -->",
+        "genre": "Groove/Alternative Metal",
+        "country": "United States",
+        "band": "12:06",
+        "preparedBandName": "12%3A06",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12%3A06/12053\">12:06</a>  <!-- 1 -->",
+            "Groove/Alternative Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/12th_Ode/3540411960",
+        "id": "3540411960",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/12th_Ode/3540411960\">12th Ode</a>  <!-- 1 -->",
+        "genre": "Heavy Metal",
+        "country": "Malta",
+        "band": "12th Ode",
+        "preparedBandName": "12th%2BOde",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/12th_Ode/3540411960\">12th Ode</a>  <!-- 1 -->",
+            "Heavy Metal",
+            "Malta"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13/3540507252",
+        "id": "3540507252",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13/3540507252\">13</a>  <!-- 1 -->",
+        "genre": "Doom Metal",
+        "country": "Brazil",
+        "band": "13",
+        "preparedBandName": "13",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13/3540507252\">13</a>  <!-- 1 -->",
+            "Doom Metal",
+            "Brazil"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13/5059",
+        "id": "5059",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13/5059\">13</a>  <!-- 1 -->",
+        "genre": "Sludge/Doom Metal",
+        "country": "United States",
+        "band": "13",
+        "preparedBandName": "13",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13/5059\">13</a>  <!-- 1 -->",
+            "Sludge/Doom Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13_A.D./3540326842",
+        "id": "3540326842",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13_A.D./3540326842\">13 A.D.</a>  <!-- 1 -->",
+        "genre": "Heavy Metal",
+        "country": "United States",
+        "band": "13 A.D.",
+        "preparedBandName": "13%2BA.D.",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13_A.D./3540326842\">13 A.D.</a>  <!-- 1 -->",
+            "Heavy Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13_Bells_of_Doom/3540443851",
+        "id": "3540443851",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13_Bells_of_Doom/3540443851\">13 Bells of Doom</a>  <!-- 1 -->",
+        "genre": "Doom Metal",
+        "country": "Chile",
+        "band": "13 Bells of Doom",
+        "preparedBandName": "13%2BBells%20of%20Doom",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13_Bells_of_Doom/3540443851\">13 Bells of Doom</a>  <!-- 1 -->",
+            "Doom Metal",
+            "Chile"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13_Burning/3540509303",
+        "id": "3540509303",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13_Burning/3540509303\">13 Burning</a>  <!-- 1 -->",
+        "genre": "Heavy Metal/Hard Rock",
+        "country": "United Kingdom",
+        "band": "13 Burning",
+        "preparedBandName": "13%2BBurning",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13_Burning/3540509303\">13 Burning</a>  <!-- 1 -->",
+            "Heavy Metal/Hard Rock",
+            "United Kingdom"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13_Candles/27489",
+        "id": "27489",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13_Candles/27489\">13 Candles</a>  <!-- 1 -->",
+        "genre": "Black Metal",
+        "country": "Netherlands",
+        "band": "13 Candles",
+        "preparedBandName": "13%2BCandles",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13_Candles/27489\">13 Candles</a>  <!-- 1 -->",
+            "Black Metal",
+            "Netherlands"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13_Candles/53909",
+        "id": "53909",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13_Candles/53909\">13 Candles</a>  <!-- 1 -->",
+        "genre": "Heavy Metal",
+        "country": "United States",
+        "band": "13 Candles",
+        "preparedBandName": "13%2BCandles",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13_Candles/53909\">13 Candles</a>  <!-- 1 -->",
+            "Heavy Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13_Days_Before_Suicide/3540366592",
+        "id": "3540366592",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13_Days_Before_Suicide/3540366592\">13 Days Before Suicide</a>  <!-- 1 -->",
+        "genre": "Melodic Death Metal",
+        "country": "Germany",
+        "band": "13 Days Before Suicide",
+        "preparedBandName": "13%2BDays%20Before%20Suicide",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13_Days_Before_Suicide/3540366592\">13 Days Before Suicide</a>  <!-- 1 -->",
+            "Melodic Death Metal",
+            "Germany"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13_Dead/3540412963",
+        "id": "3540412963",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13_Dead/3540412963\">13 Dead</a>  <!-- 1 -->",
+        "genre": "Technical/Melodic Death Metal",
+        "country": "Canada",
+        "band": "13 Dead",
+        "preparedBandName": "13%2BDead",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13_Dead/3540412963\">13 Dead</a>  <!-- 1 -->",
+            "Technical/Melodic Death Metal",
+            "Canada"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13_Killings/114945",
+        "id": "114945",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13_Killings/114945\">13 Killings</a>  <!-- 1 -->",
+        "genre": "Metalcore",
+        "country": "United States",
+        "band": "13 Killings",
+        "preparedBandName": "13%2BKillings",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13_Killings/114945\">13 Killings</a>  <!-- 1 -->",
+            "Metalcore",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13_Lashes/3540317973",
+        "id": "3540317973",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13_Lashes/3540317973\">13 Lashes</a>  <!-- 1 -->",
+        "genre": "Metalcore",
+        "country": "Canada",
+        "band": "13 Lashes",
+        "preparedBandName": "13%2BLashes",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13_Lashes/3540317973\">13 Lashes</a>  <!-- 1 -->",
+            "Metalcore",
+            "Canada"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13_Left_to_Die/3540340914",
+        "id": "3540340914",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13_Left_to_Die/3540340914\">13 Left to Die</a>  <!-- 1 -->",
+        "genre": "Thrash Metal, Metalcore",
+        "country": "Spain",
+        "band": "13 Left to Die",
+        "preparedBandName": "13%2BLeft%20to%20Die",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13_Left_to_Die/3540340914\">13 Left to Die</a>  <!-- 1 -->",
+            "Thrash Metal, Metalcore",
+            "Spain"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13_Mag/3540344198",
+        "id": "3540344198",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13_Mag/3540344198\">13 Mag</a>  <!-- 1 -->",
+        "genre": "Southern/Groove Metal",
+        "country": "United States",
+        "band": "13 Mag",
+        "preparedBandName": "13%2BMag",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13_Mag/3540344198\">13 Mag</a>  <!-- 1 -->",
+            "Southern/Groove Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13_Thrones/3540505956",
+        "id": "3540505956",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13_Thrones/3540505956\">13 Thrones</a>  <!-- 1 -->",
+        "genre": "Death Metal",
+        "country": "United States",
+        "band": "13 Thrones",
+        "preparedBandName": "13%2BThrones",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13_Thrones/3540505956\">13 Thrones</a>  <!-- 1 -->",
+            "Death Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13_Winters/19788",
+        "id": "19788",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13_Winters/19788\">13 Winters</a>  <!-- 1 -->",
+        "genre": "Symphonic Black Metal",
+        "country": "United States",
+        "band": "13 Winters",
+        "preparedBandName": "13%2BWinters",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13_Winters/19788\">13 Winters</a>  <!-- 1 -->",
+            "Symphonic Black Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13_%D0%9B%D0%B5%D0%B3%D0%B8%D0%BE%D0%BD/3540522608",
+        "id": "3540522608",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13_%D0%9B%D0%B5%D0%B3%D0%B8%D0%BE%D0%BD/3540522608\">13 Легион</a>  <!-- 1 -->",
+        "genre": "Heavy/Thrash Metal",
+        "country": "Russia",
+        "band": "13 Легион",
+        "preparedBandName": "13%2B%D0%9B%D0%B5%D0%B3%D0%B8%D0%BE%D0%BD",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13_%D0%9B%D0%B5%D0%B3%D0%B8%D0%BE%D0%BD/3540522608\">13 Легион</a>  <!-- 1 -->",
+            "Heavy/Thrash Metal",
+            "Russia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13-Digits/3540297117",
+        "id": "3540297117",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13-Digits/3540297117\">13-Digits</a>  <!-- 1 -->",
+        "genre": "Progressive Metal/Rock",
+        "country": "France",
+        "band": "13-Digits",
+        "preparedBandName": "13-Digits",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13-Digits/3540297117\">13-Digits</a>  <!-- 1 -->",
+            "Progressive Metal/Rock",
+            "France"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1310M/3540541378",
+        "id": "3540541378",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1310M/3540541378\">1310M</a>  <!-- 1 -->",
+        "genre": "Atmospheric Black Metal",
+        "country": "Ukraine",
+        "band": "1310M",
+        "preparedBandName": "1310M",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1310M/3540541378\">1310M</a>  <!-- 1 -->",
+            "Atmospheric Black Metal",
+            "Ukraine"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1347/3540481836",
+        "id": "3540481836",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1347/3540481836\">1347</a>  <!-- 1 -->",
+        "genre": "Raw Black Metal",
+        "country": "France",
+        "band": "1347",
+        "preparedBandName": "1347",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1347/3540481836\">1347</a>  <!-- 1 -->",
+            "Raw Black Metal",
+            "France"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1347/3540502592",
+        "id": "3540502592",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1347/3540502592\">1347</a>  <!-- 1 -->",
+        "genre": "Black Metal/Grindcore",
+        "country": "Indonesia",
+        "band": "1347",
+        "preparedBandName": "1347",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1347/3540502592\">1347</a>  <!-- 1 -->",
+            "Black Metal/Grindcore",
+            "Indonesia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1349/5575",
+        "id": "5575",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1349/5575\">1349</a>  <!-- 1 -->",
+        "genre": "Black Metal",
+        "country": "Norway",
+        "band": "1349",
+        "preparedBandName": "1349",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1349/5575\">1349</a>  <!-- 1 -->",
+            "Black Metal",
+            "Norway"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1369/3540293316",
+        "id": "3540293316",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1369/3540293316\">1369</a>  <!-- 1 -->",
+        "genre": "Thrash/Groove Metal",
+        "country": "United States",
+        "band": "1369",
+        "preparedBandName": "1369",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1369/3540293316\">1369</a>  <!-- 1 -->",
+            "Thrash/Groove Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1369/3540523893",
+        "id": "3540523893",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1369/3540523893\">1369</a>  <!-- 1 -->",
+        "genre": "Heavy Metal",
+        "country": "United States",
+        "band": "1369",
+        "preparedBandName": "1369",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1369/3540523893\">1369</a>  <!-- 1 -->",
+            "Heavy Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/137/14565",
+        "id": "14565",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/137/14565\">137</a>  <!-- 1 -->",
+        "genre": "Sludge/Doom Metal",
+        "country": "United States",
+        "band": "137",
+        "preparedBandName": "137",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/137/14565\">137</a>  <!-- 1 -->",
+            "Sludge/Doom Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1389/3540270259",
+        "id": "3540270259",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1389/3540270259\">1389</a>  <!-- 1 -->",
+        "genre": "Raw Black Metal",
+        "country": "Bosnia and Herzegovina",
+        "band": "1389",
+        "preparedBandName": "1389",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1389/3540270259\">1389</a>  <!-- 1 -->",
+            "Raw Black Metal",
+            "Bosnia and Herzegovina"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13Down/3540335362",
+        "id": "3540335362",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13Down/3540335362\">13Down</a>  <!-- 1 -->",
+        "genre": "Groove Metal",
+        "country": "United States",
+        "band": "13Down",
+        "preparedBandName": "13Down",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13Down/3540335362\">13Down</a>  <!-- 1 -->",
+            "Groove Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13Krieg%21/3540431224",
+        "id": "3540431224",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13Krieg%21/3540431224\">13Krieg!</a>  <!-- 1 -->",
+        "genre": "Black Metal/RAC, Crust Punk",
+        "country": "Malaysia",
+        "band": "13Krieg!",
+        "preparedBandName": "13Krieg!",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13Krieg%21/3540431224\">13Krieg!</a>  <!-- 1 -->",
+            "Black Metal/RAC, Crust Punk",
+            "Malaysia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13Nerve/124130",
+        "id": "124130",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13Nerve/124130\">13Nerve</a>  <!-- 1 -->",
+        "genre": "Groove/Death Metal",
+        "country": "Italy",
+        "band": "13Nerve",
+        "preparedBandName": "13Nerve",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13Nerve/124130\">13Nerve</a>  <!-- 1 -->",
+            "Groove/Death Metal",
+            "Italy"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13Rituals/3540293546",
+        "id": "3540293546",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13Rituals/3540293546\">13Rituals</a>  <!-- 1 -->",
+        "genre": "Deathcore",
+        "country": "Romania",
+        "band": "13Rituals",
+        "preparedBandName": "13Rituals",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13Rituals/3540293546\">13Rituals</a>  <!-- 1 -->",
+            "Deathcore",
+            "Romania"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13th_Cadaver/79118",
+        "id": "79118",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13th_Cadaver/79118\">13th Cadaver</a>  <!-- 1 -->",
+        "genre": "Death Metal",
+        "country": "United States",
+        "band": "13th Cadaver",
+        "preparedBandName": "13th%2BCadaver",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13th_Cadaver/79118\">13th Cadaver</a>  <!-- 1 -->",
+            "Death Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13th_Column/3540471054",
+        "id": "3540471054",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13th_Column/3540471054\">13th Column</a>  <!-- 1 -->",
+        "genre": "Melodic Death Metal/Deathcore",
+        "country": "Russia",
+        "band": "13th Column",
+        "preparedBandName": "13th%2BColumn",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13th_Column/3540471054\">13th Column</a>  <!-- 1 -->",
+            "Melodic Death Metal/Deathcore",
+            "Russia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13th_Embodiment/48324",
+        "id": "48324",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13th_Embodiment/48324\">13th Embodiment</a>  <!-- 1 -->",
+        "genre": "Melodic Death Metal",
+        "country": "Spain",
+        "band": "13th Embodiment",
+        "preparedBandName": "13th%2BEmbodiment",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13th_Embodiment/48324\">13th Embodiment</a>  <!-- 1 -->",
+            "Melodic Death Metal",
+            "Spain"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13th_Knot/67683",
+        "id": "67683",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13th_Knot/67683\">13th Knot</a>  <!-- 1 -->",
+        "genre": "Heavy/Power Metal",
+        "country": "United States",
+        "band": "13th Knot",
+        "preparedBandName": "13th%2BKnot",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13th_Knot/67683\">13th Knot</a>  <!-- 1 -->",
+            "Heavy/Power Metal",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13th_Level/3540257775",
+        "id": "3540257775",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13th_Level/3540257775\">13th Level</a>  <!-- 1 -->",
+        "genre": "Groove/Thrash Metal/Hardcore",
+        "country": "United States",
+        "band": "13th Level",
+        "preparedBandName": "13th%2BLevel",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13th_Level/3540257775\">13th Level</a>  <!-- 1 -->",
+            "Groove/Thrash Metal/Hardcore",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13th_Melody/26262",
+        "id": "26262",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13th_Melody/26262\">13th Melody</a>  <!-- 1 -->",
+        "genre": "Melodic Death Metal",
+        "country": "Canada",
+        "band": "13th Melody",
+        "preparedBandName": "13th%2BMelody",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13th_Melody/26262\">13th Melody</a>  <!-- 1 -->",
+            "Melodic Death Metal",
+            "Canada"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13th_Moon/3540358382",
+        "id": "3540358382",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13th_Moon/3540358382\">13th Moon</a>  <!-- 1 -->",
+        "genre": "Black/Death Metal",
+        "country": "Spain",
+        "band": "13th Moon",
+        "preparedBandName": "13th%2BMoon",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13th_Moon/3540358382\">13th Moon</a>  <!-- 1 -->",
+            "Black/Death Metal",
+            "Spain"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13th_Temple/3540419784",
+        "id": "3540419784",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13th_Temple/3540419784\">13th Temple</a>  <!-- 1 -->",
+        "genre": "Black/Doom Metal",
+        "country": "Chile",
+        "band": "13th Temple",
+        "preparedBandName": "13th%2BTemple",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13th_Temple/3540419784\">13th Temple</a>  <!-- 1 -->",
+            "Black/Doom Metal",
+            "Chile"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/13Trl/3540435110",
+        "id": "3540435110",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/13Trl/3540435110\">13Trl</a>  <!-- 1 -->",
+        "genre": "Depressive Black Metal",
+        "country": "Spain",
+        "band": "13Trl",
+        "preparedBandName": "13Trl",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/13Trl/3540435110\">13Trl</a>  <!-- 1 -->",
+            "Depressive Black Metal",
+            "Spain"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/14_Sacred_Words/3540431046",
+        "id": "3540431046",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/14_Sacred_Words/3540431046\">14 Sacred Words</a>  <!-- 1 -->",
+        "genre": "Metalcore",
+        "country": "United States",
+        "band": "14 Sacred Words",
+        "preparedBandName": "14%2BSacred%20Words",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/14_Sacred_Words/3540431046\">14 Sacred Words</a>  <!-- 1 -->",
+            "Metalcore",
+            "United States"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/14-88/3540415576",
+        "id": "3540415576",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/14-88/3540415576\">14/88</a>  <!-- 1 -->",
+        "genre": "Raw Black Metal/Noise",
+        "country": "Brazil",
+        "band": "14/88",
+        "preparedBandName": "14%2F88",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/14-88/3540415576\">14/88</a>  <!-- 1 -->",
+            "Raw Black Metal/Noise",
+            "Brazil"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/14120912519/81083",
+        "id": "81083",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/14120912519/81083\">14120912519</a>  <!-- 1 -->",
+        "genre": "Experimental Black Metal/Dark Ambient",
+        "country": "Malaysia",
+        "band": "14120912519",
+        "preparedBandName": "14120912519",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/14120912519/81083\">14120912519</a>  <!-- 1 -->",
+            "Experimental Black Metal/Dark Ambient",
+            "Malaysia"
+        ]
+    },
+    {
+        "link": "https://www.metal-archives.com/bands/1431_-_Ordo_Draconis/3540491396",
+        "id": "3540491396",
+        "originalLink": "<a href=\"https://www.metal-archives.com/bands/1431_-_Ordo_Draconis/3540491396\">1431 - Ordo Draconis</a>  <!-- 1 -->",
+        "genre": "Ambient/Black Metal",
+        "country": "Italy",
+        "band": "1431 - Ordo Draconis",
+        "preparedBandName": "1431%2B-%20Ordo%20Draconis",
+        "aaData": [
+            "<a href=\"https://www.metal-archives.com/bands/1431_-_Ordo_Draconis/3540491396\">1431 - Ordo Draconis</a>  <!-- 1 -->",
+            "Ambient/Black Metal",
+            "Italy"
+        ]
+    }
+]

--- a/tests/unit/lib/fetch.test.js
+++ b/tests/unit/lib/fetch.test.js
@@ -1,0 +1,27 @@
+import { getJSON } from '../../../src/lib/fetch.js';
+import assert from 'node:assert';
+import { mock, describe, it } from 'node:test';
+import mockData from '../../mock_data/ajax-band-search-immortal.json' assert { type: 'json' };
+
+describe('testing fetch lib', () => {
+    it('normal fetch recovery', async () => {
+        const json = () => {
+            return mockData;
+        };
+        mock.method(global, 'fetch', async () => {
+            return { json, status: 200, ok: true };
+        });
+        const data = await getJSON(
+            'https://www.metal-archives.com/search/ajax-band-search/?field=name&query=immortal&sEcho=1&iColumns=3&sColumns=&iDisplayStart=0&iDisplayLength=200&mDataProp_0=0&mDataProp_1=1&mDataProp_2=2',
+        );
+        mock.reset();
+        assert('error' in data);
+        assert('iTotalRecords' in data);
+        assert('iTotalDisplayRecords' in data);
+        assert('aaData' in data);
+    });
+    it('test for error 404 error', { todo: true });
+    it('test for error 500 error', { todo: true });
+    it('test for error other server error', { todo: true });
+    it('test for error other generic error', { todo: true });
+});

--- a/tests/unit/routes/bands/search.test.js
+++ b/tests/unit/routes/bands/search.test.js
@@ -1,0 +1,87 @@
+import { build } from '../../../../src/app.js';
+import assert from 'node:assert';
+import { mock, describe, it } from 'node:test';
+import mockData from '../../../mock_data/ajax-band-search-immortal.json' assert { type: 'json' };
+
+describe("testing 'bands/search' route", () => {
+    it('band search, no offset', async () => {
+        const json = () => {
+            return mockData;
+        };
+        mock.method(global, 'fetch', async () => {
+            return { json, status: 200, ok: true };
+        });
+        const app = build();
+        const response = await app.inject({
+            url: '/bands/search/immortal',
+        });
+        mock.reset();
+        assert.strictEqual(response.statusCode, 200);
+        assert.strictEqual(response.json().search, 'immortal');
+        assert.strictEqual(response.json().offset, 0);
+        assert.strictEqual(response.json().countTotal, 105);
+        assert.strictEqual(response.json().countCurrent, 105);
+        assert('results' in response.json());
+        assert.strictEqual(response.json().results.length, 105);
+    });
+    it('band search, defined offset', async () => {
+        const json = () => {
+            return mockData;
+        };
+        mock.method(global, 'fetch', async () => {
+            return { json, status: 200, ok: true };
+        });
+        const app = build();
+        const response = await app.inject({
+            url: '/bands/search/immortal/10',
+        });
+        mock.reset();
+        assert.strictEqual(response.statusCode, 200);
+        assert.strictEqual(response.json().search, 'immortal');
+        assert.strictEqual(response.json().offset, 10);
+        assert.strictEqual(response.json().countTotal, 105);
+        assert.strictEqual(response.json().countCurrent, 105);
+        assert('results' in response.json());
+        assert.strictEqual(response.json().results.length, 105);
+    });
+    it('missing band', async () => {
+        const json = () => {
+            return mockData;
+        };
+        mock.method(global, 'fetch', async () => {
+            return { json, status: 200, ok: true };
+        });
+        const app = build();
+        const response = await app.inject({
+            url: '/bands/search/',
+        });
+        mock.reset();
+        assert.strictEqual(response.statusCode, 400);
+    });
+    it('missing band, defined offset', async () => {
+        const json = () => {
+            return mockData;
+        };
+        mock.method(global, 'fetch', async () => {
+            return { json, status: 200, ok: true };
+        });
+        const app = build();
+        const response = await app.inject({
+            url: '/bands/search//10',
+        });
+        mock.reset();
+        assert.strictEqual(response.statusCode, 400);
+    });
+    it('test for error on getBankLinkFromHTML', { todo: true });
+    it('simulate error in FETCH', async () => {
+        mock.method(global, 'fetch', async () => {
+            return { status: 404, ok: false };
+        });
+        const app = build();
+        const response = await app.inject({
+            url: '/bands/search/some-band',
+        });
+        mock.reset();
+        assert.strictEqual(response.statusCode, 500);
+    });
+});

--- a/tests/unit/routes/bands/services/archivesSearch.test.js
+++ b/tests/unit/routes/bands/services/archivesSearch.test.js
@@ -1,0 +1,98 @@
+import { prepareBandName, prepareOffset } from '../../../../../src/routes/bands/services/archivesSearch.js';
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import mockData from '../../../../mock_data/ajax-band-search-immortal.json' assert { type: 'json' };
+import mockDataGenerated from '../../../../mock_data/complete-200-band-data.json' assert { type: 'json' };
+import esmock from 'esmock';
+
+describe('testing parameters generation', () => {
+    it('check band names slug generation, use mock data', async () => {
+        mockDataGenerated.map((element) => {
+            assert.strictEqual(prepareBandName(element.band), element.preparedBandName);
+        });
+    });
+    it('check band names slug generation, undefined', async () => {
+        assert.strictEqual(prepareBandName(undefined), '');
+    });
+    it('check offset generation, normal', () => {
+        assert.strictEqual(prepareOffset(10), 10);
+    });
+    it('check offset generation, 0', () => {
+        assert.strictEqual(prepareOffset(0), 0);
+    });
+    it('check offset generation, null', () => {
+        assert.strictEqual(prepareOffset(null), 0);
+    });
+    it('check offset generation, undefined', () => {
+        assert.strictEqual(prepareOffset(undefined), 0);
+    });
+    it('check offset generation, negative', () => {
+        assert.strictEqual(prepareOffset(-1), 0);
+    });
+    it('check offset generation, invalid', () => {
+        assert.strictEqual(prepareOffset('invalid'), 0);
+    });
+});
+describe("testing 'bands/search' route", async () => {
+    it('normal band, no offset', async () => {
+        const archivesSearch = await esmock('../../../../../src/routes/bands/services/archivesSearch.js', {
+            '../../../../../src/lib/fetch.js': {
+                getJSON: () => mockData,
+            },
+        });
+        const data = await archivesSearch.archivesSearchBand('some random band');
+        assert.strictEqual(data.error, '');
+        assert.strictEqual(data.iTotalRecords, 105);
+        assert.strictEqual(data.iTotalDisplayRecords, 105);
+        assert.strictEqual(data.aaData.length, 105);
+    });
+    it('normal band, with offset', async () => {
+        const archivesSearch = await esmock('../../../../../src/routes/bands/services/archivesSearch.js', {
+            '../../../../../src/lib/fetch.js': {
+                getJSON: () => mockData,
+            },
+        });
+        const data = await archivesSearch.archivesSearchBand('some random band', 10);
+        assert.strictEqual(data.error, '');
+        assert.strictEqual(data.iTotalRecords, 105);
+        assert.strictEqual(data.iTotalDisplayRecords, 105);
+        assert.strictEqual(data.aaData.length, 105);
+    });
+    it('empty band', async () => {
+        const archivesSearch = await esmock('../../../../../src/routes/bands/services/archivesSearch.js', {
+            '../../../../../src/lib/fetch.js': {
+                getJSON: () => mockData,
+            },
+        });
+        const data = await archivesSearch.archivesSearchBand('');
+        assert.strictEqual(data.error, '');
+        assert.strictEqual(data.iTotalRecords, 0);
+        assert.strictEqual(data.iTotalDisplayRecords, 0);
+        assert.strictEqual(data.aaData.length, 0);
+    });
+    it('empty band, force all', async () => {
+        const archivesSearch = await esmock('../../../../../src/routes/bands/services/archivesSearch.js', {
+            '../../../../../src/lib/fetch.js': {
+                getJSON: () => mockData,
+            },
+        });
+        const data = await archivesSearch.archivesSearchBand('', 10, true);
+        assert.strictEqual(data.error, '');
+        assert.strictEqual(data.iTotalRecords, 105);
+        assert.strictEqual(data.iTotalDisplayRecords, 105);
+        assert.strictEqual(data.aaData.length, 105);
+    });
+    it('normal band, invalid offset', async () => {
+        const archivesSearch = await esmock('../../../../../src/routes/bands/services/archivesSearch.js', {
+            '../../../../../src/lib/fetch.js': {
+                getJSON: () => mockData,
+            },
+        });
+        const data = await archivesSearch.archivesSearchBand('some random band', -10);
+        assert.strictEqual(data.error, '');
+        assert.strictEqual(data.iTotalRecords, 105);
+        assert.strictEqual(data.iTotalDisplayRecords, 105);
+        assert.strictEqual(data.aaData.length, 105);
+    });
+    it('test for error on getJSON', { todo: true });
+});

--- a/tests/unit/routes/bands/services/prepareBandResults.test.js
+++ b/tests/unit/routes/bands/services/prepareBandResults.test.js
@@ -1,0 +1,91 @@
+import {
+    getBandIdFromLink,
+    getBandNameFromHTML,
+    getBandLinkFromHTML,
+    prepareBandResults,
+} from '../../../../../src/routes/bands/services/prepareBandResults.js';
+import assert from 'node:assert';
+import { parse } from 'node-html-parser';
+import { describe, it } from 'node:test';
+import mockDataEmptyArchives from '../../../../mock_data/ajax-band-search-empty.json' assert { type: 'json' };
+import mockDataArchives from '../../../../mock_data/ajax-band-search-immortal.json' assert { type: 'json' };
+import mockDataGenerated from '../../../../mock_data/complete-200-band-data.json' assert { type: 'json' };
+
+describe('testing band id generation', () => {
+    it('check band id generation from generated data', async () => {
+        mockDataGenerated.map((element) => {
+            assert.strictEqual(getBandIdFromLink(element.link), element.id);
+        });
+    });
+    it('check band id generation from invalid input', async () => {
+        assert.strictEqual(getBandIdFromLink(undefined), null);
+    });
+});
+describe('testing band id generation', () => {
+    it('check band name generation', async () => {
+        mockDataGenerated.map((element) => {
+            const linkData = parse(element.originalLink);
+            assert.strictEqual(getBandNameFromHTML(linkData.firstChild), element.band);
+        });
+    });
+    it('check band name generation from invalid input', async () => {
+        assert.strictEqual(getBandNameFromHTML(undefined), null);
+    });
+});
+describe('testing band link generation', () => {
+    it('check band link generation', async () => {
+        mockDataGenerated.map((element) => {
+            const linkData = parse(element.originalLink);
+            assert.strictEqual(getBandLinkFromHTML(linkData.firstChild), element.link);
+        });
+    });
+    it('check band link generation from invalid input', async () => {
+        assert.strictEqual(getBandLinkFromHTML(undefined), null);
+    });
+    it('check band link generation from invalid input', async () => {
+        assert.strictEqual(getBandLinkFromHTML(null), null);
+    });
+    it('check band link generation from invalid input', async () => {
+        assert.strictEqual(getBandLinkFromHTML('hello'), null);
+    });
+});
+
+describe('testing prepareBandResults', () => {
+    it('check empty band data', async () => {
+        const data = mockDataEmptyArchives;
+        const results = prepareBandResults(data.aaData ?? []);
+        assert.strictEqual(results?.length, 0);
+    });
+    it('check with generated band data, check results', async () => {
+        mockDataGenerated.map((bandData) => {
+            const bands = prepareBandResults([bandData.aaData] ?? []);
+            const band = bands[0] ?? {};
+            assert.strictEqual(band.band, bandData.band);
+            assert.strictEqual(band.link, bandData.link);
+            assert.strictEqual(band.id, bandData.id);
+            assert.strictEqual(band.genre, bandData.genre);
+            assert.strictEqual(band.country, bandData.country);
+        });
+    });
+    it('check with real data, check totals', async () => {
+        const bands = prepareBandResults(mockDataArchives?.aaData ?? []);
+        assert.strictEqual(bands?.length, 105);
+    });
+    it('check with invalid data', async () => {
+        const results = prepareBandResults([
+            [
+                '<a href="https://www.metal-archives.com/bands/Immortal/25791">Immortal</a> (<strong>a.k.a.</strong> [i\'mc:tl]) <!-- 8.533402 -->',
+                'Death Metal',
+                'Denmark',
+            ],
+            [undefined, undefined, undefined],
+            [
+                '<a href="https://www.metal-archives.com/bands/Immortal/44201">Immortal</a>  <!-- 8.533402 -->',
+                'Death Metal',
+                'Malaysia',
+            ],
+        ]);
+        assert.strictEqual(results?.length, 2);
+    });
+    it('test for error on getBankLinkFromHTML', { todo: true });
+});


### PR DESCRIPTION
Added the first complete endpoint `/bands/search`

It allows to search for bands on MetalArchives, specifying a `band` (name) and an `offset` (for paging)

Added unit tests for the endpoint. This PR closes #4 